### PR TITLE
Adding 'toolchain' parameter to control rust builds

### DIFF
--- a/R/source.R
+++ b/R/source.R
@@ -12,7 +12,8 @@
 #' @param profile Rust profile. Can be either `"dev"` or `"release"`. The default,
 #'   `"dev"`, compiles faster but produces slower code.
 #' @param toolchain Rust toolchain. The default, `NULL`, compiles with the
-#'  system default toolchain. Accepts valid Rust toolchain qualifiers.
+#'  system default toolchain. Accepts valid Rust toolchain qualifiers,
+#'  such as `"nightly"`, or (on Windows) `"stable-msvc"`.
 #' @param extendr_version Version of the extendr-api crate, provided as a Rust
 #'   version string. `"*"` will use the latest available version on crates.io.
 #' @param extendr_macros_version Version of the extendr-macros crate, if different

--- a/R/source.R
+++ b/R/source.R
@@ -11,6 +11,8 @@
 #'   be added to the `Cargo.toml` file.
 #' @param profile Rust profile. Can be either `"dev"` or `"release"`. The default,
 #'   `"dev"`, compiles faster but produces slower code.
+#' @param toolchain Rust toolchain. The default, `NULL`, compiles with the
+#'  system default toolchain. Accepts valid Rust toolchain qualifiers.
 #' @param extendr_version Version of the extendr-api crate, provided as a Rust
 #'   version string. `"*"` will use the latest available version on crates.io.
 #' @param extendr_macros_version Version of the extendr-macros crate, if different

--- a/R/source.R
+++ b/R/source.R
@@ -77,7 +77,9 @@ rust_source <- function(file, code = NULL, dependencies = NULL,
                           'extendr-api = { git = "https://github.com/extendr/extendr" }',
                           'extendr-macros = { git = "https://github.com/extendr/extendr" }'
                         ),
-                        profile = c("dev", "release"), extendr_version = "*",
+                        profile = c("dev", "release"),
+                        toolchain = NULL,
+                        extendr_version = "*",
                         extendr_macros_version = extendr_version,
                         env = parent.frame(),
                         use_extendr_api = TRUE,
@@ -124,6 +126,7 @@ rust_source <- function(file, code = NULL, dependencies = NULL,
   status <- system2(
     command = "cargo",
     args = c(
+      sprintf("+%s", toolchain),
       "build",
       "--lib",
       if (!is.null(specific_target)) sprintf("--target %s", specific_target) else NULL,

--- a/man/rust_source.Rd
+++ b/man/rust_source.Rd
@@ -39,7 +39,8 @@ be added to the \code{Cargo.toml} file.}
 \code{"dev"}, compiles faster but produces slower code.}
 
 \item{toolchain}{Rust toolchain. The default, \code{NULL}, compiles with the
-system default toolchain. Accepts valid Rust toolchain qualifiers.}
+system default toolchain. Accepts valid Rust toolchain qualifiers,
+such as \code{"nightly"}, or (on Windows) \code{"stable-msvc"}.}
 
 \item{extendr_version}{Version of the extendr-api crate, provided as a Rust
 version string. \code{"*"} will use the latest available version on crates.io.}

--- a/man/rust_source.Rd
+++ b/man/rust_source.Rd
@@ -13,6 +13,7 @@ rust_source(
     patch.crates_io = c("extendr-api = { git = \\"https://github.com/extendr/extendr\\" }",
     "extendr-macros = { git = \\"https://github.com/extendr/extendr\\" }"),
   profile = c("dev", "release"),
+  toolchain = NULL,
   extendr_version = "*",
   extendr_macros_version = extendr_version,
   env = parent.frame(),
@@ -36,6 +37,9 @@ be added to the \code{Cargo.toml} file.}
 
 \item{profile}{Rust profile. Can be either \code{"dev"} or \code{"release"}. The default,
 \code{"dev"}, compiles faster but produces slower code.}
+
+\item{toolchain}{Rust toolchain. The default, \code{NULL}, compiles with the
+system default toolchain. Accepts valid Rust toolchain qualifiers.}
 
 \item{extendr_version}{Version of the extendr-api crate, provided as a Rust
 version string. \code{"*"} will use the latest available version on crates.io.}


### PR DESCRIPTION
Fixes #19.
`toolchain` parameter allows overriding default toolchain used system-wide when building rust libraries.
In most cases, the default toolchain is the preferred choice, but on Windows default toolchain can be `*-msvc`, which requires `MSYS2` installed for linking. In such a scenario, `toolchain` allows using `*-gnu` to compile `rextendr` chunks without overriding system default.