### PR TITLE
Add meaningful tests to rextendr

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -3,10 +3,12 @@ on:
     branches:
       - main
       - master
+      - updated-tests
   pull_request:
     branches:
       - main
       - master
+  workflow_dispatch:
 
 name: R-CMD-check
 
@@ -14,16 +16,16 @@ jobs:
   R-CMD-check:
     runs-on: ${{ matrix.config.os }}
 
-    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }} / ${{ matrix.config.rust-version }})
 
     strategy:
       fail-fast: false
       matrix:
         config:
-          - {os: windows-latest, r: 'release'}
-          - {os: macOS-latest, r: 'release'}
-          - {os: ubuntu-20.04, r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
-          - {os: ubuntu-20.04, r: 'devel', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
+          - {os: windows-latest, r: 'release', rust-version: 'stable-gnu'}
+          - {os: macOS-latest, r: 'release', rust-version: 'stable'}
+          - {os: ubuntu-20.04, r: 'release', rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
+          - {os: ubuntu-20.04, r: 'devel', rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
@@ -31,12 +33,23 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.config.rust-version }}
+          default: true
 
-      - uses: r-lib/actions/setup-r@v1
+      # Uses @master branch to address rtools path issue
+      # https://github.com/r-lib/actions/issues/228
+      - name: Set up R
+        uses: r-lib/actions/setup-r@master
         with:
           r-version: ${{ matrix.config.r }}
+          windows-path-include-mingw: false
 
-      - uses: r-lib/actions/setup-pandoc@v1
+      - name: Set up pandoc
+        uses: r-lib/actions/setup-pandoc@v1
 
       - name: Query dependencies
         run: |
@@ -45,16 +58,16 @@ jobs:
           writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
         shell: Rscript {0}
 
-      - name: Cache R packages
-        if: runner.os != 'Windows'
+      - name: Cache R packages (not Windows)
+        if: startsWith(runner.os, 'Windows') == false
         uses: actions/cache@v2
         with:
           path: ${{ env.R_LIBS_USER }}
           key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
           restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
 
-      - name: Install system dependencies
-        if: runner.os == 'Linux'
+      - name: Configure Linux
+        if: startsWith(runner.os, 'Linux')
         run: |
           while read -r cmd
           do

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -66,6 +66,12 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
           restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
 
+      - name: Configure Windows
+        if: startsWith(runner.os, 'Windows')
+        run: |
+          rustup target add x86_64-pc-windows-gnu
+          rustup target add i686-pc-windows-gnu
+
       - name: Configure Linux
         if: startsWith(runner.os, 'Linux')
         run: |
@@ -73,6 +79,7 @@ jobs:
           do
             eval sudo $cmd
           done < <(Rscript -e 'writeLines(remotes::system_requirements("ubuntu", "20.04"))')
+
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -23,9 +23,9 @@ jobs:
       matrix:
         config:
           - {os: windows-latest, r: 'release', rust-version: 'stable-gnu'}
-          - {os: macOS-latest, r: 'release', rust-version: 'stable'}
-          - {os: ubuntu-20.04, r: 'release', rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
-          - {os: ubuntu-20.04, r: 'devel', rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
+          # - {os: macOS-latest, r: 'release', rust-version: 'stable'}
+          # - {os: ubuntu-20.04, r: 'release', rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
+          # - {os: ubuntu-20.04, r: 'devel', rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
@@ -71,6 +71,8 @@ jobs:
         run: |
           rustup target add x86_64-pc-windows-gnu
           rustup target add i686-pc-windows-gnu
+          $env:PATH -split [System.IO.Path]::PathSeparator
+        shell: pwsh
 
       - name: Configure Linux
         if: startsWith(runner.os, 'Linux')

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -3,12 +3,10 @@ on:
     branches:
       - main
       - master
-      - updated-tests
   pull_request:
     branches:
       - main
       - master
-  workflow_dispatch:
 
 name: R-CMD-check
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -88,14 +88,16 @@ jobs:
         shell: Rscript {0}
 
       - name: Check
+        id: rcmd_check
         env:
           _R_CHECK_CRAN_INCOMING_REMOTE_: false
-        run: rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran"), error_on = "warning", check_dir = "check")
+        run: rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran", "--force-multiarch"), error_on = "warning", check_dir = "check")
         shell: Rscript {0}
 
       - name: Upload check results
         if: failure()
         uses: actions/upload-artifact@main
         with:
-          name: ${{ runner.os }}-r${{ matrix.config.r }}-results
+          name: ${{ runner.os }}-r${{ matrix.config.r }}-rust${{ matrix.config.rust-version }}-results
           path: check
+

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -23,9 +23,9 @@ jobs:
       matrix:
         config:
           - {os: windows-latest, r: 'release', rust-version: 'stable-msvc'}
-          # - {os: macOS-latest, r: 'release', rust-version: 'stable'}
-          # - {os: ubuntu-20.04, r: 'release', rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
-          # - {os: ubuntu-20.04, r: 'devel', rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
+          - {os: macOS-latest, r: 'release', rust-version: 'stable'}
+          - {os: ubuntu-20.04, r: 'release', rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
+          - {os: ubuntu-20.04, r: 'devel', rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: windows-latest, r: 'release', rust-version: 'stable-gnu'}
+          - {os: windows-latest, r: 'release', rust-version: 'stable-msvc'}
           # - {os: macOS-latest, r: 'release', rust-version: 'stable'}
           # - {os: ubuntu-20.04, r: 'release', rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
           # - {os: ubuntu-20.04, r: 'devel', rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
@@ -71,7 +71,8 @@ jobs:
         run: |
           rustup target add x86_64-pc-windows-gnu
           rustup target add i686-pc-windows-gnu
-          $env:PATH -split [System.IO.Path]::PathSeparator
+          echo "C:\msys64\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append 
+          echo "C:\msys64\mingw32\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
         shell: pwsh
 
       - name: Configure Linux

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -2,7 +2,9 @@ library(testthat)
 library(rextendr)
 
 # no need to run tests if cargo isn't installed.
-result <- system2("cargo")
-if (result == 0L) {
+cargo_available <- system2("cargo") == 0L
+not_cran <- identical(Sys.getenv("NOT_CRAN"), "true")
+
+if (cargo_available && not_cran) {
   test_check("rextendr")
 }

--- a/tests/testthat/test-name-override.R
+++ b/tests/testthat/test-name-override.R
@@ -1,0 +1,41 @@
+test_that("Multiple rust functions with the same name", {
+    skip_on_cran()
+    rust_src_1 <- "
+    #[extendr]
+    fn rust_fn_1() -> i32 { 1i32 }
+
+    #[extendr]
+    fn rust_fn_2() -> i32 { 2i32 }
+    "
+
+    rust_src_2 <- "
+    #[extendr]
+    fn rust_fn_2() -> i32 { 20i32 }
+
+    #[extendr]
+    fn rust_fn_3() -> i32 { 30i32 }
+    "
+
+    rust_source(code = rust_src_1, quiet = FALSE)
+
+    # At this point:
+    # fn1 -> 1
+    # fn2 -> 2
+    # fn3 -> (not exported)
+
+    expect_equal(rust_fn_1(), 1L)
+    expect_equal(rust_fn_2(), 2L)
+
+    rust_source(code = rust_src_2, quiet = FALSE)
+
+    # At this point:
+    # fn1 -> 1 (unchanged)
+    # fn2 -> 20 (changed)
+    # fn3 -> 30 (new function)
+
+    expect_equal(rust_fn_1(), 1L)
+    expect_equal(rust_fn_2(), 20L)
+    expect_equal(rust_fn_3(), 30L)
+
+
+})

--- a/tests/testthat/test-name-override.R
+++ b/tests/testthat/test-name-override.R
@@ -1,5 +1,5 @@
 test_that("Multiple rust functions with the same name", {
-    skip_on_cran()
+
     rust_src_1 <- "
     #[extendr]
     fn rust_fn_1() -> i32 { 1i32 }

--- a/tests/testthat/test-source.R
+++ b/tests/testthat/test-source.R
@@ -38,4 +38,7 @@ test_that("Testing the source", {
   #> [1] 37
   expect_equal(add(17, 42), 17 + 42)
 
+  # This function takes no arguments and invisibly return NULL
+  expect_null(say_nothing())
+
 })

--- a/tests/testthat/test-source.R
+++ b/tests/testthat/test-source.R
@@ -1,5 +1,4 @@
 test_that("Testing the source", {
-  skip_on_cran()
 
   rust_src <- "
     #[extendr]

--- a/tests/testthat/test-source.R
+++ b/tests/testthat/test-source.R
@@ -1,14 +1,7 @@
-# implementation of actual tests will require updated extendr-api, extendr-macros, libR-sys
-# on crates.io.
-
 test_that("Testing the source", {
-  # skip("This would typically fail, unless changed to reflect paths /
-  #      on host's machine. ")
-  # some simple Rust code with two functions
   skip_on_cran()
 
-  rust_src <- "use extendr_api::*;
-
+  rust_src <- "
     #[extendr]
     fn hello() -> &'static str {
         \"Hello, this string was created by Rust.\"
@@ -32,11 +25,6 @@ test_that("Testing the source", {
 
   rust_source(
     code = rust_src,
-    # use `patch.crates_io` argument to override crate locations
-    # patch.crates_io = c(
-    #   'extendr-api = {path = "C:/Users/tpb398/Documents/GitHub/extendR/extendr-api"}',
-    #   'extendr-macros = {path = "C:/Users/tpb398/Documents/GitHub/extendR/extendr-macros"}'
-    # ),
     quiet = FALSE,
     cache_build = TRUE
   )

--- a/tests/testthat/test-source.R
+++ b/tests/testthat/test-source.R
@@ -2,9 +2,11 @@
 # on crates.io.
 
 test_that("Testing the source", {
-  skip("This would typically fail, unless changed to reflect paths /
-       on host's machine. ")
+  # skip("This would typically fail, unless changed to reflect paths /
+  #      on host's machine. ")
   # some simple Rust code with two functions
+  skip_on_cran()
+
   rust_src <- "use extendr_api::*;
 
     #[extendr]
@@ -31,17 +33,17 @@ test_that("Testing the source", {
   rust_source(
     code = rust_src,
     # use `patch.crates_io` argument to override crate locations
-    patch.crates_io = c(
-      'extendr-api = {path = "C:/Users/tpb398/Documents/GitHub/extendR/extendr-api"}',
-      'extendr-macros = {path = "C:/Users/tpb398/Documents/GitHub/extendR/extendr-macros"}'
-    ),
+    # patch.crates_io = c(
+    #   'extendr-api = {path = "C:/Users/tpb398/Documents/GitHub/extendR/extendr-api"}',
+    #   'extendr-macros = {path = "C:/Users/tpb398/Documents/GitHub/extendR/extendr-macros"}'
+    # ),
     quiet = FALSE,
     cache_build = TRUE
   )
 
   # call `hello()` function from R
-  hello()
   #> [1] "Hello, this string was created by Rust."
+  expect_equal(hello(), "Hello, this string was created by Rust.")
 
   # call `add()` function from R
   expect_equal(add(14, 23), 37)


### PR DESCRIPTION
In this PR I enable existing tests and add a few more -- to check boundary cases and wrapper generation.
Test are executed on *not CRAN* using `skip_on_cran()`.
This works out of the box on GHA because it sets `NOT_CRAN = "true"` by default.

I pass additional argument `--force-multiarch` to `rcmdcheck` to ensure Windows has both builds tested.

Because of #19 issues, Windows uses `stable-msvc` toolchain and pre-installed `MSYS2` (added to the `PATH`).

This PR is possible because I took the liberty of fixing my own error in PR #24.