### PR TITLE
Default windows toolchain set to `gnu`

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -38,6 +38,12 @@ jobs:
         with:
           toolchain: ${{ matrix.config.rust-version }}
           default: true
+      
+      - name: Configure second Rust toolchain (Windows)
+        if: startsWith(runner.os, 'Windows') && endsWith(matrix.config.rust-version, 'gnu')
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable-i686-gnu
 
       # Uses @master branch to address rtools path issue
       # https://github.com/r-lib/actions/issues/228
@@ -65,10 +71,6 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
           restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
 
-      - name: Configure Windows
-        if: startsWith(runner.os, 'Windows')
-        run: |
-            rustup toolchain add stable-i686-pc-windows-gnu
 
       - name: Configure Linux
         if: startsWith(runner.os, 'Linux')

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -3,7 +3,6 @@ on:
     branches:
       - main
       - master
-      - default-windows-toolchain
   pull_request:
     branches:
       - main

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -3,6 +3,7 @@ on:
     branches:
       - main
       - master
+      - default-windows-toolchain
   pull_request:
     branches:
       - main
@@ -20,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: windows-latest, r: 'release', rust-version: 'stable-msvc'}
+          - {os: windows-latest, r: 'release', rust-version: 'stable-gnu'}
           - {os: macOS-latest, r: 'release', rust-version: 'stable'}
           - {os: ubuntu-20.04, r: 'release', rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
           - {os: ubuntu-20.04, r: 'devel', rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
@@ -67,11 +68,7 @@ jobs:
       - name: Configure Windows
         if: startsWith(runner.os, 'Windows')
         run: |
-          rustup target add x86_64-pc-windows-gnu
-          rustup target add i686-pc-windows-gnu
-          echo "C:\msys64\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append 
-          echo "C:\msys64\mingw32\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-        shell: pwsh
+            rustup toolchain add stable-i686-pc-windows-gnu
 
       - name: Configure Linux
         if: startsWith(runner.os, 'Linux')

--- a/R/source.R
+++ b/R/source.R
@@ -126,6 +126,12 @@ rust_source <- function(file, code = NULL, dependencies = NULL,
   # Get target name, not null for Windows
   specific_target <- get_specific_target_name()
 
+  # On Windows, if no toolchain specified,
+  # use arch-dependent stable-gnu
+  if (.Platform$OS.type == "windows" && is.null(toolchain)) {
+    toolchain <- paste0("stable-", specific_target)
+  }
+
   status <- system2(
     command = "cargo",
     args = c(


### PR DESCRIPTION
In continuation to #25 and discussion in #19.

The current agreement is that if no `toolchain` is passed to R functions on Windows, we use `stable-x86_64-gnu` for 64 bit and `stable-i686-gnu` for 32 bit.
If however `toolchain` is provided, its value is used as-is, which allows overrides, e.g. `stable-msvc` with `MSYS2` linker.