### PR TITLE
Update setting_up_rust vignette about MSYS2 path

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -140,7 +140,7 @@ Content not found. Please use links in the navbar.
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.6.0.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.6.1.</p>
 </div>
 
       </footer>

--- a/docs/LICENSE-text.html
+++ b/docs/LICENSE-text.html
@@ -142,7 +142,7 @@ COPYRIGHT HOLDER: Claus O. Wilke, Andy Thomason, Mossa M. Reimert
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.6.0.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.6.1.</p>
 </div>
 
       </footer>

--- a/docs/LICENSE.html
+++ b/docs/LICENSE.html
@@ -146,7 +146,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.6.0.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.6.1.</p>
 </div>
 
       </footer>

--- a/docs/articles/index.html
+++ b/docs/articles/index.html
@@ -141,7 +141,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.6.0.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.6.1.</p>
 </div>
 
       </footer>

--- a/docs/articles/rmarkdown.html
+++ b/docs/articles/rmarkdown.html
@@ -246,7 +246,7 @@ The quick *brown fox* jumps over the lazy dog."</span>
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.6.0.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.6.1.</p>
 </div>
 
       </footer>

--- a/docs/articles/setting_up_rust.html
+++ b/docs/articles/setting_up_rust.html
@@ -78,7 +78,7 @@
       <h1 data-toc-skip>Setting up a Rust build environment</h1>
                         <h4 class="author">Claus O. Wilke</h4>
             
-            <h4 class="date">2021-01-16</h4>
+            <h4 class="date">2021-01-17</h4>
       
       
       <div class="hidden name"><code>setting_up_rust.Rmd</code></div>
@@ -98,8 +98,8 @@ rustup target add i686-pc-windows-gnu</code></pre>
 <p>Once msys2 is installed, install the mingw toolchain. We recommend doing this for both 32 and 64 bit.</p>
 <pre><code>pacman -S --noconfirm mingw-w64-x86_64-toolchain   # 64-bit
 pacman -S --noconfirm mingw-w64-i686-toolchain     # 32-bit</code></pre>
-<p>Finally, add the msys2 bin paths to the <code>PATH</code> environment variable. For example, if you installed msys2 into <code>C:\msys2</code>, these would be <code>C:\msys2\usr\bin</code>, <code>C:\msys2\mingw64\bin</code>, and <code>C:\msys2\mingw32\bin</code>, and you could run (using the CMD shell):</p>
-<pre><code>set PATH=C:\msys2\usr\bin;C:\msys2\mingw64\bin;C:\msys2\mingw32\bin;%PATH%</code></pre>
+<p>Finally, add the msys2 bin paths to the <code>PATH</code> environment variable. For example, if you installed msys2 into <code>C:\msys64</code>, these would be <code>C:\msys64\usr\bin</code>, <code>C:\msys64\mingw64\bin</code>, and <code>C:\msys64\mingw32\bin</code>, and you could run (using the CMD shell):</p>
+<pre><code>set PATH=C:\msys64\usr\bin;C:\msys64\mingw64\bin;C:\msys64\mingw32\bin;%PATH%</code></pre>
   </div>
 
   <div class="col-md-3 hidden-xs hidden-sm" id="pkgdown-sidebar">

--- a/docs/articles/setting_up_rust.html
+++ b/docs/articles/setting_up_rust.html
@@ -98,8 +98,8 @@ rustup target add i686-pc-windows-gnu</code></pre>
 <p>Once msys2 is installed, install the mingw toolchain. We recommend doing this for both 32 and 64 bit.</p>
 <pre><code>pacman -S --noconfirm mingw-w64-x86_64-toolchain   # 64-bit
 pacman -S --noconfirm mingw-w64-i686-toolchain     # 32-bit</code></pre>
-<p>Finally, add the msys2 bin paths to the <code>PATH</code> environment variable. For example, if you installed msys2 into <code>C:\msys32</code>, these would be <code>C:\msys32\usr\bin</code>, <code>C:\msys32\mingw32\bin</code>, and <code>C:\msys32\mingw64\bin</code>, and you could run (using the CMD shell):</p>
-<pre><code>set PATH=C:\msys32\usr\bin;C:\msys32\mingw32\bin;C:\msys32\mingw64\bin;%PATH%</code></pre>
+<p>Finally, add the msys2 bin paths to the <code>PATH</code> environment variable. For example, if you installed msys2 into <code>C:\msys2</code>, these would be <code>C:\msys2\usr\bin</code>, <code>C:\msys2\mingw64\bin</code>, and <code>C:\msys2\mingw32\bin</code>, and you could run (using the CMD shell):</p>
+<pre><code>set PATH=C:\msys2\usr\bin;C:\msys2\mingw64\bin;C:\msys2\mingw32\bin;%PATH%</code></pre>
   </div>
 
   <div class="col-md-3 hidden-xs hidden-sm" id="pkgdown-sidebar">
@@ -115,7 +115,7 @@ pacman -S --noconfirm mingw-w64-i686-toolchain     # 32-bit</code></pre>
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.6.0.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.6.1.</p>
 </div>
 
       </footer>

--- a/docs/authors.html
+++ b/docs/authors.html
@@ -147,7 +147,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.6.0.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.6.1.</p>
 </div>
 
       </footer>

--- a/docs/index.html
+++ b/docs/index.html
@@ -160,7 +160,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.6.0.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.6.1.</p>
 </div>
 
       </footer>

--- a/docs/pkgdown.yml
+++ b/docs/pkgdown.yml
@@ -1,6 +1,8 @@
-pandoc: 2.11.1
-pkgdown: 1.6.0
+pandoc: 2.11.2
+pkgdown: 1.6.1
 pkgdown_sha: ~
-articles: []
-last_built: 2021-01-16T08:09Z
+articles:
+  rmarkdown: rmarkdown.html
+  setting_up_rust: setting_up_rust.html
+last_built: 2021-01-16T11:47Z
 

--- a/docs/reference/eng_extendr.html
+++ b/docs/reference/eng_extendr.html
@@ -163,7 +163,7 @@ exported to R).</p>
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.6.0.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.6.1.</p>
 </div>
 
       </footer>

--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -177,7 +177,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.6.0.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.6.1.</p>
 </div>
 
       </footer>

--- a/docs/reference/rextendr.html
+++ b/docs/reference/rextendr.html
@@ -147,7 +147,7 @@ See <code><a href='rust_source.html'>rust_source()</a></code> for details.</p>
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.6.0.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.6.1.</p>
 </div>
 
       </footer>

--- a/docs/reference/rust_eval.html
+++ b/docs/reference/rust_eval.html
@@ -189,7 +189,7 @@ worry about it in your code.</p>
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.6.0.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.6.1.</p>
 </div>
 
       </footer>

--- a/docs/reference/rust_source.html
+++ b/docs/reference/rust_source.html
@@ -283,7 +283,7 @@ The quick *brown fox* jumps over the lazy dog."</span>
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.6.0.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.6.1.</p>
 </div>
 
       </footer>

--- a/vignettes/setting_up_rust.Rmd
+++ b/vignettes/setting_up_rust.Rmd
@@ -35,7 +35,7 @@ pacman -S --noconfirm mingw-w64-x86_64-toolchain   # 64-bit
 pacman -S --noconfirm mingw-w64-i686-toolchain     # 32-bit
 ```
 
-Finally, add the msys2 bin paths to the `PATH` environment variable. For example, if you installed msys2 into `C:\msys32`, these would be `C:\msys32\usr\bin`, `C:\msys32\mingw32\bin`, and `C:\msys32\mingw64\bin`, and you could run (using the CMD shell):
+Finally, add the msys2 bin paths to the `PATH` environment variable. For example, if you installed msys2 into `C:\msys2`, these would be `C:\msys2\usr\bin`, `C:\msys2\mingw64\bin`, and `C:\msys2\mingw32\bin`, and you could run (using the CMD shell):
 ```
-set PATH=C:\msys32\usr\bin;C:\msys32\mingw32\bin;C:\msys32\mingw64\bin;%PATH%
+set PATH=C:\msys2\usr\bin;C:\msys2\mingw64\bin;C:\msys2\mingw32\bin;%PATH%
 ```

--- a/vignettes/setting_up_rust.Rmd
+++ b/vignettes/setting_up_rust.Rmd
@@ -35,7 +35,7 @@ pacman -S --noconfirm mingw-w64-x86_64-toolchain   # 64-bit
 pacman -S --noconfirm mingw-w64-i686-toolchain     # 32-bit
 ```
 
-Finally, add the msys2 bin paths to the `PATH` environment variable. For example, if you installed msys2 into `C:\msys2`, these would be `C:\msys2\usr\bin`, `C:\msys2\mingw64\bin`, and `C:\msys2\mingw32\bin`, and you could run (using the CMD shell):
+Finally, add the msys2 bin paths to the `PATH` environment variable. For example, if you installed msys2 into `C:\msys64`, these would be `C:\msys64\usr\bin`, `C:\msys64\mingw64\bin`, and `C:\msys64\mingw32\bin`, and you could run (using the CMD shell):
 ```
-set PATH=C:\msys2\usr\bin;C:\msys2\mingw64\bin;C:\msys2\mingw32\bin;%PATH%
+set PATH=C:\msys64\usr\bin;C:\msys64\mingw64\bin;C:\msys64\mingw32\bin;%PATH%
 ```


### PR DESCRIPTION
* Change MSYS2 example path to ~~`C\:msys2`~~ `C:\msys64`
* Change the PATH order; `mingw64` first and `mingw32` second
* Rebuild pkgdown site