### PR TITLE
Configuring tests using environment variables

### DIFF
--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -6,19 +6,27 @@ cargo_available <- system2("cargo") == 0L
 not_cran <- identical(Sys.getenv("NOT_CRAN"), "true")
 
 if (cargo_available && not_cran) {
+  # This retrieves exrepssions that represent
+  # default arguments of rust_source,
+  # which are used for reference
   test_env <- formals(rextendr::rust_source)
 
+  # Toolchain is a string, so can be read as is
   toolchain <- Sys.getenv("REXTENDR_TOOLCHAIN")
   if (!is.null(toolchain) && nzchar(toolchain)) {
     test_env$toolchain <- toolchain
     message(paste0(">> {rextendr}: Using toolchain from 'REXTENDR_TOOLCHAIN': ", toolchain))
   }
 
+  # Patch is represented as vector of character.
+  # In environment variable different crates are separated using ';'
+  # E.g., "extendr-api = { git = \"https://github.com/extendr/extendr\" };extendr-macros = { git = \"https://github.com/extendr/extendr\" }"
   patch <- Sys.getenv("REXTENDR_PATCH_CRATES_IO")
   if (!is.null(patch) && nzchar(patch)) {
     test_env$patch.crates_io <- strsplit(patch, ";")[[1]]
     message(paste0(">> {rextendr}: Using cargo patch from 'REXTENDR_PATCH_CRATES_IO': ", patch))
   } else {
+    # Patch should be evaluated because it can be represented as a vector
     test_env$patch.crates_io <- eval(test_env$patch.crates_io)
   }
 

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -6,5 +6,21 @@ cargo_available <- system2("cargo") == 0L
 not_cran <- identical(Sys.getenv("NOT_CRAN"), "true")
 
 if (cargo_available && not_cran) {
+  test_env <- formals(rextendr::rust_source)
+
+  toolchain <- Sys.getenv("REXTENDR_TOOLCHAIN")
+  if (!is.null(toolchain) && nzchar(toolchain)) {
+    test_env$toolchain <- toolchain
+    message(paste0(">> {rextendr}: Using toolchain from 'REXTENDR_TOOLCHAIN': ", toolchain))
+  }
+
+  patch <- Sys.getenv("REXTENDR_PATCH_CRATES_IO")
+  if (!is.null(patch) && nzchar(patch)) {
+    test_env$patch.crates_io <- strsplit(patch, ";")[[1]]
+    message(paste0(">> {rextendr}: Using cargo patch from 'REXTENDR_PATCH_CRATES_IO': ", patch))
+  } else {
+    test_env$patch.crates_io <- eval(test_env$patch.crates_io)
+  }
+
   test_check("rextendr")
 }

--- a/tests/testthat/test-name-override.R
+++ b/tests/testthat/test-name-override.R
@@ -16,7 +16,12 @@ test_that("Multiple rust functions with the same name", {
     fn rust_fn_3() -> i32 { 30i32 }
     "
 
-    rust_source(code = rust_src_1, quiet = FALSE)
+    rust_source(
+        code = rust_src_1,
+        quiet = FALSE,
+        toolchain = test_env[["toolchain"]],
+        patch.crates_io = test_env[["patch.crates_io"]]
+    )
 
     # At this point:
     # fn1 -> 1
@@ -26,7 +31,12 @@ test_that("Multiple rust functions with the same name", {
     expect_equal(rust_fn_1(), 1L)
     expect_equal(rust_fn_2(), 2L)
 
-    rust_source(code = rust_src_2, quiet = FALSE)
+    rust_source(
+        code = rust_src_2,
+        quiet = FALSE,
+        toolchain = test_env[["toolchain"]],
+        patch.crates_io = test_env[["patch.crates_io"]]
+    )
 
     # At this point:
     # fn1 -> 1 (unchanged)

--- a/tests/testthat/test-source.R
+++ b/tests/testthat/test-source.R
@@ -25,7 +25,9 @@ test_that("Testing the source", {
   rust_source(
     code = rust_src,
     quiet = FALSE,
-    cache_build = TRUE
+    cache_build = TRUE,
+    toolchain = test_env[["toolchain"]],
+    patch.crates_io = test_env[["patch.crates_io"]]
   )
 
   # call `hello()` function from R


### PR DESCRIPTION
Continues discussion in and fixes #30.
The idea is to be able to control how {rextendr} builds rust code in tests using environment variables.
E.g., if tests should be executed using a different toolchain, use `REXTENDR_TOOLCHAIN`:
```R
Sys.setenv(REXTENDR_TOOLCHAIN = "stable-x86_64-pc-windows-gnu")
rcmdcheck::rcmdcheck(".")
```

Currently, only two variables are supported, `REXTENDR_TOOLCHAIN` and `REXTENDR_PATCH_CRATES_IO`.
Different crates patches can be separated using `';'`.

If the environment variable is not set (or it is an equivalent of an empty string), default values from `rust_source` are used.