### PR TITLE
Update LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,2 +1,2 @@
-YEAR: 2021
+YEAR: 2020
 COPYRIGHT HOLDER: rextendr authors

--- a/LICENSE
+++ b/LICENSE
@@ -1,2 +1,2 @@
-YEAR: 2020
-COPYRIGHT HOLDER: Claus O. Wilke, Andy Thomason, Mossa M. Reimert
+YEAR: 2021
+COPYRIGHT HOLDER: rextendr authors

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # MIT License
 
-Copyright (c) 2020 Claus O. Wilke, Andy Thomason, Mossa M. Reimert
+Copyright (c) 2021 rextendr authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # MIT License
 
-Copyright (c) 2021 rextendr authors
+Copyright (c) 2020 rextendr authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
A little more infrastructure cleanup, this time with `use_mit_license()`, which was out of date