### PR TITLE
Updating extendr options in markdown

### DIFF
--- a/vignettes/rmarkdown.Rmd
+++ b/vignettes/rmarkdown.Rmd
@@ -201,7 +201,7 @@ fn md_to_html(input: &str) -> String {
 ````
 
 As before, the Rust code chunk just outputs the source:
-```{extendrsrc engine.opts = list(dependencies = 'pulldown-cmark = "0.8"')}
+```{extendrsrc engine.opts = list(dependencies = list(`pulldown-cmark` = "0.8"))}
 use pulldown_cmark::{Parser, Options, html};
 
 #[extendr]


### PR DESCRIPTION
An old-style `dependency` argument prevented pkgdown from building the website.
The error was triggered by #44.
This PR replaces `dependency` with a serialization-compatible value.