### PR TITLE
Fixing code sample in markdown

### DIFF
--- a/vignettes/rmarkdown.Rmd
+++ b/vignettes/rmarkdown.Rmd
@@ -185,7 +185,7 @@ x$get()
 If your code requires external crates, you can set dependencies via the `engine.opts` chunk option, like so:
 
 ````markdown
-`r ''````{extendrfuns engine.opts = list(dependencies = 'pulldown-cmark = "0.8"')}
+`r ''````{extendrfuns engine.opts = list(dependencies = list(`pulldown-cmark` = "0.8"))}
 use pulldown_cmark::{Parser, Options, html};
 
 #[extendr]


### PR DESCRIPTION
I fixed the actual code that caused pkgdown to fail but not the exact same code displayed to the user...
Supplements #45.