### PR TITLE
Fixing bug in toml serialization

### DIFF
--- a/R/toml_serialization.R
+++ b/R/toml_serialization.R
@@ -131,7 +131,6 @@ format_toml.data.frame <- function(x,
                                    .top_level = FALSE) {
   rows <- nrow(x)
   header <- glue("[[{.tbl_name}]]")
-
   if (rows == 0L) {
     return(as.character(header))
   }
@@ -139,7 +138,7 @@ format_toml.data.frame <- function(x,
     map(
       seq_len(rows),
       function(idx) {
-        item <- simplify_row(x[idx, ])
+        item <- simplify_row(dplyr::slice(x, idx))
         if (length(item) == 0L) {
           result <- character(0)
         } else {

--- a/tests/testthat/test-toml.R
+++ b/tests/testthat/test-toml.R
@@ -35,6 +35,12 @@ test_that("`toml` is generated correctly", {
       test = FALSE,
       doc = FALSE
     ),
+    empty_table = data.frame(),
+    table_array = data.frame(
+      x = c(1L, NA_integer_, 2L),
+      y = c("1", NA_character_, "2")
+    ),
+    single_row_array = data.frame(x = 1),
     .str_as_literal = FALSE
   )
 
@@ -62,7 +68,17 @@ test_that("`toml` is generated correctly", {
     "[[lib]]",
     "name = \"cargo\"",
     "test = false",
-    "doc = false"
+    "doc = false",
+    "[[empty_table]]",
+    "[[table_array]]",
+    "x = 1",
+    "y = \"1\"",
+    "[[table_array]]",
+    "[[table_array]]",
+    "x = 2",
+    "y = \"2\"",
+    "[[single_row_array]]",
+    "x = 1"
   )
 
   expect_equal(toml, reference)


### PR DESCRIPTION
I found a small bug in toml serialization of [array-of-tables](https://toml.io/en/v1.0.0#array-of-tables), when R's `data.frame` has only one column, e.g. `data.frame(x = 1)`.
This is caused by inconsistent (in my opinion) behavior of `[i, ]`, which in the case of one column returns not the data.frame row (as named list), but rather the contents of the column (which I honestly never noticed).
```R
data.frame(x = 1, y = 1)[1, ]
x y
1 1
data.frame(x = 1)[1, ]
[1] 1
```

My choice of `[,]` operator was bad, so I suggest to replace it with `dplyr::slice`, which does the job by internally calling `vctrs::vec_slice`, which is type- and size-stable.

I have added extra tests to verify the code works in the edge cases.