### PR TITLE
Removing {fs} dependency (Fixes #69)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,7 +41,6 @@ Imports:
     desc,
     devtools,
     dplyr,
-    fs,
     glue,
     pkgbuild,
     pkgload,

--- a/R/register_extendr.R
+++ b/R/register_extendr.R
@@ -92,7 +92,7 @@ register_extendr <- function(path = ".", quiet = FALSE, force_wrappers = FALSE, 
 #' @param path Path from which package root is looked up. Used for message formatting.
 #' @param use_symbols Logical, indicating wether to add additonal symbol information to
 #' the generated wrappers. Default (`FALSE`) is used when making wrappers for the package,
-#' while `TRUE` is used to make wrappers for dynamically generated libraries using 
+#' while `TRUE` is used to make wrappers for dynamically generated libraries using
 #' [`rust_source`], [`rust_function`], etc.
 #' @param quiet Logical scalar indicating whether the output should be quiet (`TRUE`)
 #'   or verbose (`FALSE`).
@@ -124,9 +124,8 @@ make_wrappers <- function(module_name, package_name, outfile,
 #' @param compile Logical indicating whether the library should be recompiled.
 #' @keywords internal
 make_wrappers_externally <- function(module_name, package_name, outfile,
-                                    path, use_symbols = FALSE, quiet = FALSE,
-                                    compile = NA) {
-
+                                     path, use_symbols = FALSE, quiet = FALSE,
+                                     compile = NA) {
   func <- function(path, make_wrappers, compile, quiet,
                    module_name, package_name, outfile,
                    use_symbols, ...) {
@@ -141,7 +140,7 @@ make_wrappers_externally <- function(module_name, package_name, outfile,
       )
     }
 
-    dll_path <- fs::path(path, "src", paste0(package_name, .Platform$dynlib.ext))
+    dll_path <- file.path(path, "src", paste0(package_name, .Platform$dynlib.ext))
     # Loads native library
     lib <- dyn.load(dll_path)
     # Registers library unloading to be invoked at the end of this function

--- a/R/track_rust_source.R
+++ b/R/track_rust_source.R
@@ -195,7 +195,8 @@ needs_compilation <- function(path = ".", quiet = FALSE) {
 # @returns A `tibble::tibble()` with information about files,
 # including `path` and `mtime`, which are used elsewhere in `rextendr`.
 get_file_info <- function(path) {
-  info <- file.info(path)
+  # We do not need extra columns, only `mtime`
+  info <- file.info(path, extra_cols = FALSE)
   info <- dplyr::mutate(info, path = rownames(info), .before = dplyr::everything())
   tibble::as_tibble(info)
 }

--- a/R/track_rust_source.R
+++ b/R/track_rust_source.R
@@ -14,7 +14,7 @@ pretty_rel_path <- function(path, search_from = ".") {
   )
 
   # Absolute path.
-  # `path` may not exists, so `mustWork` suppresses unnecessary warnings.
+  # `path` may not exist, so `mustWork` suppresses unnecessary warnings.
   path <- normalizePath(path, winslash = "/", mustWork = FALSE)
 
   # If `package_root` is not parent of `path`,
@@ -155,7 +155,7 @@ needs_compilation <- function(path = ".", quiet = FALSE) {
   TRUE
 }
 
-# Replaces `fs::file_info`.
+# Equivalent to `fs::file_info`.
 #
 # Takes paths, retrieves info using `file.info`
 # and converts obtained `data.frame` in a more suitable `tibble`

--- a/R/track_rust_source.R
+++ b/R/track_rust_source.R
@@ -1,3 +1,23 @@
+#' Returns `default` value if `expr` throws an error.
+#'
+#' This allows to silently handle errors and return a pre-defined
+#' default value.
+#' @param expr An expression to invoke (can be anything).
+#' @param default Value to return if `expr` throws an error.
+#' @return Either the result of `expr` or `default`. No
+#' type checks or type coersions performed.
+#' @example
+#' on_error_return_default(stop("This will be consumed"), "You get this instead")
+#' @noRd
+on_error_return_default <- function(expr, default = NULL) {
+  tryCatch(
+    expr,
+    error = function(e) {
+      default
+    }
+  )
+}
+
 # Converts any path to path, relative to the package root
 # E.g., outer_root/some_folder/code/packages/my_package/src/rust/src/lib.rs
 # becomes src/rust/src/lib.rs.
@@ -7,23 +27,33 @@
 # @param search_from Path from which package root is looked up.
 # @returns `path`, relative to the package root.
 pretty_rel_path <- function(path, search_from = ".") {
-  # Absolute path to the package root
-  package_root <- normalizePath(
-    rprojroot::find_package_root_file(path = search_from),
-    winslash = "/"
-  )
+  # Absolute path to the package root.
+  # If package root cannot be identified,
+  # an error is thrown, which gets converted into
+  # `""` using `on_error_return_default`.
+  package_root <-
+    on_error_return_default(
+      normalizePath(
+        rprojroot::find_package_root_file(path = search_from),
+        winslash = "/"
+      ),
+      default = ""
+    )
 
   # Absolute path.
   # `path` may not exist, so `mustWork` suppresses unnecessary warnings.
   path <- normalizePath(path, winslash = "/", mustWork = FALSE)
 
-  # If `package_root` is not parent of `path`,
-  # return `path` unchanged (for simplicity)
-  if (!stringi::stri_detect_fixed(
-    str = path,
-    pattern = package_root,
-    case_insensitive = TRUE
-  )) {
+  # If `package_root` is empty or not a parent of `path`,
+  # return `path` unchanged (for simplicity).
+  if (
+    !nzchar(package_root) ||
+      !stringi::stri_detect_fixed(
+        str = path,
+        pattern = package_root,
+        case_insensitive = TRUE
+      )
+  ) {
     return(path)
   }
 

--- a/R/track_rust_source.R
+++ b/R/track_rust_source.R
@@ -59,7 +59,7 @@ pretty_rel_path <- function(path, search_from = ".") {
 
   # If `path` is a subpath of `package_root`,
   # then `path` contains `package_root` as a substring.
-  # This removes `pacakge_root` substring from `path`,
+  # This removes `package_root` substring from `path`,
   # performing comparison case_insensitively.
   path <- stringi::stri_replace_first_fixed(
     str = path,

--- a/R/use_extendr.R
+++ b/R/use_extendr.R
@@ -35,8 +35,8 @@ use_extendr <- function(path = ".", quiet = FALSE) {
     return(invisible(FALSE))
   }
 
-  rust_src_dir <- fs::path(src_dir, "rust", "src")
-  fs::dir_create(rust_src_dir, recurse = TRUE)
+  rust_src_dir <- file.path(src_dir, "rust", "src")
+  dir.create(rust_src_dir, recursive = TRUE)
   cli::cli_alert_success("Creating {.file {pretty_rel_path(rust_src_dir, path)}}.")
 
   entrypoint_content <- glue(
@@ -51,7 +51,7 @@ void R_init_{pkg_name}(void *dll) {{
 }}
 )"
   )
-  usethis::write_over(fs::path(src_dir, "entrypoint.c"), entrypoint_content, quiet = quiet)
+  usethis::write_over(file.path(src_dir, "entrypoint.c"), entrypoint_content, quiet = quiet)
 
   makevars_content <- glue(
     "
@@ -73,7 +73,7 @@ clean:
 \trm -Rf $(SHLIB) $(STATLIB) $(OBJECTS) rust/target
 "
   )
-  usethis::write_over(fs::path(src_dir, "Makevars"), makevars_content, quiet = quiet)
+  usethis::write_over(file.path(src_dir, "Makevars"), makevars_content, quiet = quiet)
 
   makevars_win_content <- glue(
     "
@@ -96,21 +96,21 @@ clean:
 \trm -Rf $(SHLIB) $(STATLIB) $(OBJECTS) rust/target
 "
   )
-  usethis::write_over(fs::path(src_dir, "Makevars.win"), makevars_win_content, quiet = quiet)
+  usethis::write_over(file.path(src_dir, "Makevars.win"), makevars_win_content, quiet = quiet)
 
   gitignore_content <- "*.o
 *.so
 *.dll
 target
 "
-  usethis::write_over(fs::path(src_dir, ".gitignore"), gitignore_content, quiet = quiet)
+  usethis::write_over(file.path(src_dir, ".gitignore"), gitignore_content, quiet = quiet)
 
   cargo_toml_content <- to_toml(
     package = list(name = pkg_name, version = "0.1.0", edition = "2018"),
     lib = list(`crate-type` = array("staticlib", 1)),
     dependencies = list(`extendr-api` = "*")
   )
-  usethis::write_over(fs::path(src_dir, "rust", "Cargo.toml"), cargo_toml_content, quiet = quiet)
+  usethis::write_over(file.path(src_dir, "rust", "Cargo.toml"), cargo_toml_content, quiet = quiet)
 
   lib_rs_content <- glue(
     r"(
@@ -133,7 +133,7 @@ extendr_module! {{
 )"
   )
 
-  usethis::write_over(fs::path(rust_src_dir, "lib.rs"), lib_rs_content, quiet = quiet)
+  usethis::write_over(file.path(rust_src_dir, "lib.rs"), lib_rs_content, quiet = quiet)
 
 
   roxcmt <- "#'" # workaround for roxygen parsing bug in raw strings

--- a/tests/testthat/test-helper-functions.R
+++ b/tests/testthat/test-helper-functions.R
@@ -98,8 +98,8 @@ test_that("`pretty_rel_path()` works", {
 
 # Verifies that `rextendr::get_file_info()` returns the same as base R
 # `file.info()` for files and directories.
-test_that("`get_file_info()` and `file.info()` outptus are equivalent", {
-  n_test_files <- 10L
+test_that("`get_file_info()` and `file.info()` outputs are equivalent", {
+  n_test_files <- 3L
   n_test_dirs <- 2L
   # Creates 10 temp files in 10 *different* temp directories,
   # each file prefixed with its index (1 to 10)

--- a/tests/testthat/test-helper-functions.R
+++ b/tests/testthat/test-helper-functions.R
@@ -101,8 +101,8 @@ test_that("`pretty_rel_path()` works", {
 test_that("`get_file_info()` and `file.info()` outputs are equivalent", {
   n_test_files <- 3L
   n_test_dirs <- 2L
-  # Creates 10 temp files in 10 *different* temp directories,
-  # each file prefixed with its index (1 to 10)
+  # Creates 3 temp files in 3 *different* temp directories,
+  # each file prefixed with its index (1 to 3)
   temp_files <- purrr::map_chr(
     seq_len(n_test_files),
     ~ tempfile(pattern = as.character(.x))

--- a/tests/testthat/test-helper-functions.R
+++ b/tests/testthat/test-helper-functions.R
@@ -7,14 +7,15 @@
 # first argument.
 test_that("`pretty_rel_path()` works", {
   tempdir <- tempdir()
-  pkg_root <- normalizePath(file.path(tempdir, "testpkg"), winslash = "/")
+  pkg_root <- file.path(tempdir, "testpkg")
+  dir.create(pkg_root, recursive = TRUE)
+  pkg_root <- normalizePath(pkg_root, winslash = "/")
   sink(nullfile())
   tryCatch(
     devtools::create(pkg_root),
     finally = sink()
   )
   rextendr::use_extendr(pkg_root, quiet = TRUE)
-
 
   # Find relative path from package root, trivial case
   expect_equal(

--- a/tests/testthat/test-helper-functions.R
+++ b/tests/testthat/test-helper-functions.R
@@ -94,3 +94,53 @@ test_that("`pretty_rel_path()` works", {
     "A/B/C/D.F"
   )
 })
+
+
+# Verifies that `rextendr::get_file_info()` returns the same as base R
+# `file.info()` for files and directories.
+test_that("`get_file_info()` and `file.info()` outptus are equivalent", {
+  n_test_files <- 10L
+  n_test_dirs <- 2L
+  # Creates 10 temp files in 10 *different* temp directories,
+  # each file prefixed with its index (1 to 10)
+  temp_files <- purrr::map_chr(
+    seq_len(n_test_files),
+    ~ tempfile(pattern = as.character(.x))
+  )
+
+  # Creates 2 temporary directories
+  temp_dirs <- purrr::map_chr(
+    seq_len(n_test_dirs),
+    ~ tempdir()
+  )
+
+  # Test both files & directories
+  temp_paths <- c(temp_files, temp_dirs)
+
+  # Gets file info using base R. This returns a `data.frame`,
+  # where rownames contain (absolute) paths.
+  base_info <- file.info(temp_paths, extra_cols = FALSE)
+
+  # Gets file info using rextendr function. This returns a `tibble`,
+  # similar to base R, but file paths are now recorded in column `path`.
+  rextendr_info <- get_file_info(temp_paths)
+
+  expect_equal(rownames(base_info), rextendr_info[["path"]])
+  expect_equal(base_info[["size"]], rextendr_info[["size"]])
+  expect_equal(base_info[["isdir"]], rextendr_info[["isdir"]])
+  expect_equal(base_info[["mode"]], rextendr_info[["mode"]])
+  expect_equal(base_info[["mtime"]], rextendr_info[["mtime"]])
+  expect_equal(base_info[["ctime"]], rextendr_info[["ctime"]])
+  expect_equal(base_info[["atime"]], rextendr_info[["atime"]])
+
+  # A file that does not exist has `NA` in all columns.
+  na_info <- get_file_info("non_existent.file")
+
+  expect_equal(na_info[["path"]], "non_existent.file")
+  expect_true(is.na(na_info[["size"]]))
+  expect_true(is.na(na_info[["isdir"]]))
+  expect_true(is.na(na_info[["mode"]]))
+  expect_true(is.na(na_info[["mtime"]]))
+  expect_true(is.na(na_info[["ctime"]]))
+  expect_true(is.na(na_info[["atime"]]))
+})

--- a/tests/testthat/test-helper-functions.R
+++ b/tests/testthat/test-helper-functions.R
@@ -7,7 +7,7 @@
 # first argument.
 test_that("`pretty_rel_path()` works", {
   tempdir <- tempdir()
-  pkg_root <- file.path(tempdir, "testpkg")
+  pkg_root <- normalizePath(file.path(tempdir, "testpkg"), winslash = "/")
   sink(nullfile())
   tryCatch(
     devtools::create(pkg_root),

--- a/tests/testthat/test-helper-functions.R
+++ b/tests/testthat/test-helper-functions.R
@@ -1,0 +1,95 @@
+
+# Test if `pretty_rel_path` determines relative paths correctly.
+# Edge cases include initiating the search from a directory outside of
+# package directory (an ancestor/parent in the hierarchy), and
+# from a non-exstenst/invalid directory (such as `NA` or `""`),
+# in which case `pretty_rel_path` should return absolute path of itr
+# first argument.
+test_that("`pretty_rel_path()` works", {
+  tempdir <- tempdir()
+  pkg_root <- file.path(tempdir, "testpkg")
+  sink(nullfile())
+  tryCatch(
+    devtools::create(pkg_root),
+    finally = sink()
+  )
+  rextendr::use_extendr(pkg_root, quiet = TRUE)
+
+
+  # Find relative path from package root, trivial case
+  expect_equal(
+    pretty_rel_path(
+      file.path(pkg_root, "R", "extendr-wrappers.R"),
+      pkg_root
+    ),
+    "R/extendr-wrappers.R"
+  )
+
+  # Find relative path starting from a subdirectory of package
+  expect_equal(
+    pretty_rel_path(
+      file.path(pkg_root, "R", "extendr-wrappers.R"),
+      file.path(pkg_root, "src", "rust", "src", "lib.rs")
+    ),
+    "R/extendr-wrappers.R"
+  )
+
+  # Find relative path starting outside of package directory.
+  # This should return the absolute path of the file (not relative).
+  expect_equal(
+    pretty_rel_path(
+      file.path(pkg_root, "R", "extendr-wrappers.R"),
+      file.path(pkg_root, "..")
+    ),
+    normalizePath(
+      file.path(pkg_root, "R", "extendr-wrappers.R"),
+      winslash = "/"
+    )
+  )
+
+  # Find relative path providing no input for the package directory.
+  # This should return the absolute path of the file (not relative).
+  expect_equal(
+    pretty_rel_path(
+      file.path(pkg_root, "R", "extendr-wrappers.R"),
+      ""
+    ),
+    normalizePath(
+      file.path(pkg_root, "R", "extendr-wrappers.R"),
+      winslash = "/"
+    )
+  )
+
+  # Same as the one above, but providing NA_character_
+  expect_equal(
+    pretty_rel_path(
+      file.path(pkg_root, "R", "extendr-wrappers.R"),
+      NA_character_
+    ),
+    normalizePath(
+      file.path(pkg_root, "R", "extendr-wrappers.R"),
+      winslash = "/"
+    )
+  )
+
+  # Same as the one above, but providing empty character vector
+  expect_equal(
+    pretty_rel_path(
+      file.path(pkg_root, "R", "extendr-wrappers.R"),
+      character(0)
+    ),
+    normalizePath(
+      file.path(pkg_root, "R", "extendr-wrappers.R"),
+      winslash = "/"
+    )
+  )
+
+  # Test path to non-existent file
+  expect_equal(
+    pretty_rel_path(
+      file.path(pkg_root, "A", "B", "C", "D.F"),
+      pkg_root
+    ),
+    "A/B/C/D.F"
+  )
+})


### PR DESCRIPTION
Removes {fs} in favor of base R (with some minor limitations). Fixes #69.