### PR TITLE
Remove {usethis}

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -47,8 +47,7 @@ Imports:
     stringi,
     tibble,
     rlang (>= 0.4.10),
-    rprojroot,
-    usethis,
+    rprojroot
 Suggests: 
     devtools,
     knitr,

--- a/R/register_extendr.R
+++ b/R/register_extendr.R
@@ -139,13 +139,12 @@ make_wrappers <- function(module_name, package_name, outfile,
   )
   x <- stringi::stri_split_lines1(x)
 
-  # Can't use usethis::write_over because it asks user for input if
-  # file already exists.
-  brio::write_lines(x, outfile)
-  if (!isTRUE(quiet)) {
-    rel_path <- pretty_rel_path(outfile, search_from = path)
-    cli::cli_alert_success("Writing wrappers to {.file {rel_path}}.")
-  }
+  write_file(
+    text = x,
+    path = outfile,
+    search_root_from = path,
+    quiet = quiet
+  )
 }
 
 #' Creates R wrappers for Rust functions.

--- a/R/use_extendr.R
+++ b/R/use_extendr.R
@@ -51,7 +51,13 @@ void R_init_{pkg_name}(void *dll) {{
 }}
 )"
   )
-  usethis::write_over(file.path(src_dir, "entrypoint.c"), entrypoint_content, quiet = quiet)
+  # usethis::write_over(file.path(src_dir, "entrypoint.c"), entrypoint_content, quiet = quiet)
+  write_file(
+    text = entrypoint_content,
+    path = file.path(src_dir, "entrypoint.c"),
+    search_root_from = path,
+    quiet = quiet
+  )
 
   makevars_content <- glue(
     "
@@ -73,7 +79,13 @@ clean:
 \trm -Rf $(SHLIB) $(STATLIB) $(OBJECTS) rust/target
 "
   )
-  usethis::write_over(file.path(src_dir, "Makevars"), makevars_content, quiet = quiet)
+  # usethis::write_over(file.path(src_dir, "Makevars"), makevars_content, quiet = quiet)
+  write_file(
+    text = makevars_content,
+    path = file.path(src_dir, "Makevars"),
+    search_root_from = path,
+    quiet = quiet
+  )
 
   makevars_win_content <- glue(
     "
@@ -96,21 +108,41 @@ clean:
 \trm -Rf $(SHLIB) $(STATLIB) $(OBJECTS) rust/target
 "
   )
-  usethis::write_over(file.path(src_dir, "Makevars.win"), makevars_win_content, quiet = quiet)
+  # usethis::write_over(file.path(src_dir, "Makevars.win"), makevars_win_content, quiet = quiet)
+  write_file(
+    text = makevars_win_content,
+    path = file.path(src_dir, "Makevars.win"),
+    search_root_from = path,
+    quiet = quiet
+  )
+
 
   gitignore_content <- "*.o
 *.so
 *.dll
 target
 "
-  usethis::write_over(file.path(src_dir, ".gitignore"), gitignore_content, quiet = quiet)
+  # usethis::write_over(file.path(src_dir, ".gitignore"), gitignore_content, quiet = quiet)
+  write_file(
+    text = gitignore_content,
+    path = file.path(src_dir, ".gitignore"),
+    search_root_from = path,
+    quiet = quiet
+  )
 
   cargo_toml_content <- to_toml(
     package = list(name = pkg_name, version = "0.1.0", edition = "2018"),
     lib = list(`crate-type` = array("staticlib", 1)),
     dependencies = list(`extendr-api` = "*")
   )
-  usethis::write_over(file.path(src_dir, "rust", "Cargo.toml"), cargo_toml_content, quiet = quiet)
+  # usethis::write_over(file.path(src_dir, "rust", "Cargo.toml"), cargo_toml_content, quiet = quiet)
+  write_file(
+    text = cargo_toml_content,
+    path = file.path(src_dir, "rust", "Cargo.toml"),
+    search_root_from = path,
+    quiet = quiet
+  )
+
 
   lib_rs_content <- glue(
     r"(
@@ -133,7 +165,13 @@ extendr_module! {{
 )"
   )
 
-  usethis::write_over(file.path(rust_src_dir, "lib.rs"), lib_rs_content, quiet = quiet)
+  # usethis::write_over(file.path(rust_src_dir, "lib.rs"), lib_rs_content, quiet = quiet)
+  write_file(
+    text = lib_rs_content,
+    path = file.path(rust_src_dir, "lib.rs"),
+    search_root_from = path,
+    quiet = quiet
+  )
 
 
   roxcmt <- "#'" # workaround for roxygen parsing bug in raw strings

--- a/R/use_extendr.R
+++ b/R/use_extendr.R
@@ -51,7 +51,7 @@ void R_init_{pkg_name}(void *dll) {{
 }}
 )"
   )
-  # usethis::write_over(file.path(src_dir, "entrypoint.c"), entrypoint_content, quiet = quiet)
+
   write_file(
     text = entrypoint_content,
     path = file.path(src_dir, "entrypoint.c"),
@@ -79,7 +79,7 @@ clean:
 \trm -Rf $(SHLIB) $(STATLIB) $(OBJECTS) rust/target
 "
   )
-  # usethis::write_over(file.path(src_dir, "Makevars"), makevars_content, quiet = quiet)
+
   write_file(
     text = makevars_content,
     path = file.path(src_dir, "Makevars"),
@@ -108,7 +108,7 @@ clean:
 \trm -Rf $(SHLIB) $(STATLIB) $(OBJECTS) rust/target
 "
   )
-  # usethis::write_over(file.path(src_dir, "Makevars.win"), makevars_win_content, quiet = quiet)
+
   write_file(
     text = makevars_win_content,
     path = file.path(src_dir, "Makevars.win"),
@@ -122,7 +122,7 @@ clean:
 *.dll
 target
 "
-  # usethis::write_over(file.path(src_dir, ".gitignore"), gitignore_content, quiet = quiet)
+
   write_file(
     text = gitignore_content,
     path = file.path(src_dir, ".gitignore"),
@@ -135,7 +135,7 @@ target
     lib = list(`crate-type` = array("staticlib", 1)),
     dependencies = list(`extendr-api` = "*")
   )
-  # usethis::write_over(file.path(src_dir, "rust", "Cargo.toml"), cargo_toml_content, quiet = quiet)
+
   write_file(
     text = cargo_toml_content,
     path = file.path(src_dir, "rust", "Cargo.toml"),
@@ -165,7 +165,7 @@ extendr_module! {{
 )"
   )
 
-  # usethis::write_over(file.path(rust_src_dir, "lib.rs"), lib_rs_content, quiet = quiet)
+
   write_file(
     text = lib_rs_content,
     path = file.path(rust_src_dir, "lib.rs"),

--- a/R/write_file.R
+++ b/R/write_file.R
@@ -1,7 +1,7 @@
 #' Writes text to file
 #'
-#' This function is a wrapper around [`brio::write_lines`].
-#' It also supports verboe output, similar to [`usethis::write_over`],
+#' This function is a wrapper around [`brio::write_lines()`].
+#' It also supports verboe output, similar to [`usethis::write_over()`],
 #' controlled by the `quiet` parameter.
 #' @param text Character vector containing text to write.
 #' @param path A string giving the file path to write to.
@@ -10,7 +10,7 @@
 #' Unused if `quiet == TRUE`.
 #' @param quiet Logical scalar indicating whether the output should be quiet (`TRUE`)
 #'   or verbose (`FALSE`).
-#' @return The output of [`brio::write_lines`] (invisibly).
+#' @return The output of [`brio::write_lines()`] (invisibly).
 #' @noRd
 write_file <- function(text, path, search_root_from = ".", quiet = FALSE) {
   output <- brio::write_lines(text = text, path = path)

--- a/R/write_file.R
+++ b/R/write_file.R
@@ -1,13 +1,14 @@
 #' Writes text to file
 #'
 #' This function is a wrapper around [`brio::write_lines()`].
-#' It also supports verboe output, similar to [`usethis::write_over()`],
+#' It also supports verbose output, similar to [`usethis::write_over()`],
 #' controlled by the `quiet` parameter.
 #' @param text Character vector containing text to write.
 #' @param path A string giving the file path to write to.
-#' @param search_root_from A string giving path to a package subfolder,
-#' which is used to find package root and produce message for the user.
-#' Unused if `quiet == TRUE`.
+#' @param search_root_from This parameter only affects messages displayed to the user. 
+#' It has no effect on where the file is written.
+#' It gets passed to [`pretty_rel_path()`] if `quiet = FALSE`.
+#' It is unused otherwise.
 #' @param quiet Logical scalar indicating whether the output should be quiet (`TRUE`)
 #'   or verbose (`FALSE`).
 #' @return The output of [`brio::write_lines()`] (invisibly).

--- a/R/write_file.R
+++ b/R/write_file.R
@@ -1,0 +1,22 @@
+#' Writes text to file
+#'
+#' This function is a wrapper around [`brio::write_lines`].
+#' It also supports verboe output, similar to [`usethis::write_over`],
+#' controlled by the `quiet` parameter.
+#' @param text Character vector containing text to write.
+#' @param path A string giving the file path to write to.
+#' @param search_root_from A string giving path to a package subfolder,
+#' which is used to find package root and produce message for the user.
+#' Unused if `quiet == TRUE`.
+#' @param quiet Logical scalar indicating whether the output should be quiet (`TRUE`)
+#'   or verbose (`FALSE`).
+#' @return The output of [`brio::write_lines`] (invisibly).
+#' @noRd
+write_file <- function(text, path, search_root_from = ".", quiet = FALSE) {
+  output <- brio::write_lines(text = text, path = path)
+  if (!isTRUE(quiet)) {
+    rel_path <- pretty_rel_path(path, search_from = search_root_from)
+    cli::cli_alert_success("Writing file {.file {rel_path}}.")
+  }
+  invisible(output)
+}

--- a/tests/testthat/test-helper-functions.R
+++ b/tests/testthat/test-helper-functions.R
@@ -285,18 +285,8 @@ test_that("`write_file()` does the same as `brio::write_lines()`", {
   )
 
   # Creating two temp files for {rextendr} and {brio}.
-  # `normalizePath` is needed moslty on Windows. It ensures
-  # paths are absolute and use `'/'` as directory separators.
-  temp_file_rxr <- normalizePath(
-    tempfile(pattern = "rxr_"),
-    winslash = "/",
-    mustWork = FALSE
-  )
-  temp_file_brio <- normalizePath(
-    tempfile(pattern = "brio_"),
-    winslash = "/",
-    mustWork = FALSE
-  )
+  temp_file_rxr <- tempfile(pattern = "rxr_")
+  temp_file_brio <- tempfile(pattern = "brio_")
 
   # Explicitly removing temporary files
   on.exit(
@@ -314,11 +304,13 @@ test_that("`write_file()` does the same as `brio::write_lines()`", {
 
   # Verifies file content
   expect_equal(readLines(temp_file_rxr), readLines(temp_file_brio))
+  # Obtaines 'relative path' that is displayed to the user.
+  rel_path <- pretty_rel_path(temp_file_rxr, ".")
   # Verifies displayed message
   expect_equal(
     ui_message,
     cli::cli_format_method(
-      cli::cli_alert_success("Writing file {.file {temp_file_rxr}}.")
+      cli::cli_alert_success("Writing file {.file {rel_path}}.")
     )
   )
 })


### PR DESCRIPTION
Fixes #70. Removes explicit usage of {usethis} (mainly, `usethis::write_over()`).
Introduces `rextendr::write_file()`, a wrapper around `brio::write_lines()` that displays verbose messages if operation succeeds.