### PR TITLE
Update ui functions

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -6,3 +6,4 @@
 ^\.github$
 ^docs$
 ^_pkgdown\.yml$
+^principles\.md$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -53,9 +53,7 @@ Suggests:
     knitr,
     rmarkdown,
     rstudioapi,
-    testthat,
-    usethis,
-    withr
+    testthat
 VignetteBuilder: 
     knitr
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,10 +25,10 @@ Authors@R:
              role = "aut",
              email = "yutani.ini@gmail.com",
              comment = c(ORCID = "0000-0002-3385-7233")))
-Description: Call Rust code from R. This package provides
-    functions to compile and load Rust code from R, similar to how 'Rcpp'
-    or 'cpp11' allow easy interfacing with C++ code. Under the hood, the
-    package uses the Rust 'extendr' crate to do all the heavy lifting.
+Description: Call Rust code from R. This package provides functions to
+    compile and load Rust code from R, similar to how 'Rcpp' or 'cpp11'
+    allow easy interfacing with C++ code. Under the hood, the package uses
+    the Rust 'extendr' crate to do all the heavy lifting.
 License: MIT + file LICENSE
 URL: https://github.com/extendr/rextendr
 BugReports: https://github.com/extendr/rextendr/issues
@@ -44,21 +44,23 @@ Imports:
     pkgbuild,
     pkgload,
     purrr,
-    stringi,
-    tibble,
     rlang (>= 0.4.10),
-    rprojroot
+    rprojroot,
+    stringi,
+    tibble
 Suggests: 
     devtools,
     knitr,
     rmarkdown,
     rstudioapi,
-    testthat
+    testthat,
+    usethis,
+    withr
 VignetteBuilder: 
     knitr
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.1
-SystemRequirements: Rust 'cargo'; the crate 'libR-sys' must
-    compile without error
+SystemRequirements: Rust 'cargo'; the crate 'libR-sys' must compile
+    without error

--- a/R/clean_code.R
+++ b/R/clean_code.R
@@ -83,10 +83,10 @@ fill_block_comments <- function(lns, fill_with = " ") {
     ui_throw(
       "Malformed comments.",
       c(
-        bullet("x", "Number of start {.code /*} and end {.code */} \\
+        bullet_x("Number of start {.code /*} and end {.code */} \\
                delimiters are not equal."),
-        bullet("i", "Found {n_open} occurence{?s} of {.code /*}."),
-        bullet("i", "Found {n_close} occurence{?s} of {.code */}.")
+        bullet_i("Found {n_open} occurence{?s} of {.code /*}."),
+        bullet_i("Found {n_close} occurence{?s} of {.code */}.")
       )
     )
   }
@@ -117,8 +117,8 @@ fill_block_comments <- function(lns, fill_with = " ") {
     ui_throw(
       "Malformed comments.",
       c(
-        bullet("x", "{.code /*} and {.code */} are not paired correctly."),
-        bullet("i", "This error may be caused by a code fragment like \\
+        bullet_x("{.code /*} and {.code */} are not paired correctly."),
+        bullet_i("This error may be caused by a code fragment like \\
                {.code */ ... /*}.")
       )
     )

--- a/R/clean_code.R
+++ b/R/clean_code.R
@@ -48,7 +48,7 @@ fill_block_comments <- function(lns, fill_with = " ") {
   # Fast path if no comments are found at all.
   if (
     all(is.na(comment_syms[["start"]])) &&
-      all(is.na(comment_syms[["end"]]))
+    all(is.na(comment_syms[["end"]]))
   ) {
     return(
       stringi::stri_split_lines(
@@ -80,16 +80,14 @@ fill_block_comments <- function(lns, fill_with = " ") {
   n_close <- sum(valid_syms[["type"]] == "close")
   # Fails if number of `/*` and `*/` are different.
   if (n_open != n_close) {
-    stop(
-      glue(
-        "Malformed comments.",
-        "x Number of start `/*` and end `*/` delimiters are not equal.",
-        "i Found `{n_open}` occurence(s) of `/*`.",
-        "i Found `{n_close}` occurence(s) of `*/`.",
-        .sep = "\n ",
-        .trim = FALSE
-      ),
-      call. = FALSE
+    ui_throw(
+      "Malformed comments.",
+      c(
+        bullet("x", "Number of start {.code /*} and end {.code */} \\
+               delimiters are not equal."),
+        bullet("i", "Found {n_open} occurence{?s} of {.code /*}."),
+        bullet("i", "Found {n_close} occurence{?s} of {.code */}.")
+      )
     )
   }
 
@@ -114,17 +112,15 @@ fill_block_comments <- function(lns, fill_with = " ") {
   n_valid <- nrow(to_replace)
   if (
     any(to_replace[["type"]][2L * seq_len(n_valid / 2L) - 1L] != "open") ||
-      any(to_replace[["type"]][2L * seq_len(n_valid / 2L)] != "close")
+    any(to_replace[["type"]][2L * seq_len(n_valid / 2L)] != "close")
   ) {
-    stop(
-      glue(
-        "Malformed comments.",
-        "x `/*` and `*/` are not paired correctly.",
-        "i This error may be caused by a code fragment like `*/ ... /*`.",
-        .sep = "\n ",
-        .trim = FALSE
-      ),
-      call. = FALSE
+    ui_throw(
+      "Malformed comments.",
+      c(
+        bullet("x", "{.code /*} and {.code */} are not paired correctly."),
+        bullet("i", "This error may be caused by a code fragment like \\
+               {.code */ ... /*}.")
+      )
     )
   }
   # Manual `pivot_wider`.

--- a/R/eval.R
+++ b/R/eval.R
@@ -34,7 +34,7 @@ rust_eval <- function(code, env = parent.frame(), ...) {
 
   # define to make R code check happy; is not used
   rextendr_rust_eval_fun <- function() {
-    stop("decoy function; should never be called.")
+    ui_throw("decoy function; should never be called.")
   }
 
   # wrap code into Rust function

--- a/R/find_exports.R
+++ b/R/find_exports.R
@@ -42,15 +42,13 @@ extract_meta <- function(lns) {
       glue_collapse(lns, sep = "\n  "),
       1, 80
     )
-    stop(
-      glue(
-        "Rust code contains invalid attribute macros.",
-        "x No valid `fn` or `impl` block found in the following sample:",
-        "`{code_sample}`",
-        .sep = "\n ",
-        .trim = FALSE
-      ),
-      call. = FALSE
+    ui_throw(
+      "Rust code contains invalid attribute macros.",
+      c(
+        bullet("x", "No valid `fn` or `impl` block found in the following \\
+               sample:"),
+        "{.code {code_sample}}"
+      )
     )
   }
   result

--- a/R/find_exports.R
+++ b/R/find_exports.R
@@ -45,9 +45,9 @@ extract_meta <- function(lns) {
     ui_throw(
       "Rust code contains invalid attribute macros.",
       c(
-        bullet("x", "No valid `fn` or `impl` block found in the following \\
-               sample:"),
-        cli_format_text("{.code {code_sample}}")
+        bullet("x", "No valid {.code fn} or {.code impl} block found in the \\
+          following sample:"),
+        code_sample
       )
     )
   }

--- a/R/find_exports.R
+++ b/R/find_exports.R
@@ -45,7 +45,7 @@ extract_meta <- function(lns) {
     ui_throw(
       "Rust code contains invalid attribute macros.",
       c(
-        bullet("x", "No valid {.code fn} or {.code impl} block found in the \\
+        bullet_x("No valid {.code fn} or {.code impl} block found in the \\
           following sample:"),
         code_sample
       )

--- a/R/find_exports.R
+++ b/R/find_exports.R
@@ -47,9 +47,10 @@ extract_meta <- function(lns) {
       c(
         bullet("x", "No valid `fn` or `impl` block found in the following \\
                sample:"),
-        "{.code {code_sample}}"
+        cli_format_text("{.code {code_sample}}")
       )
     )
   }
   result
 }
+

--- a/R/install_libR_bindings.R
+++ b/R/install_libR_bindings.R
@@ -19,15 +19,12 @@
 install_libR_bindings <- function(version = "*", force = FALSE, quiet = FALSE, patch.crates_io = NULL) {
   package_dir <- find.package("rextendr")
   if (file.access(package_dir, 2) != 0L) {
-    stop(
-      "Cannot write to package location: ", package_dir,
-      call. = FALSE
-    )
+    ui_throw("Cannot write to package location: {package_dir}")
   }
 
   bindings_file <- file.path(package_dir, "rust", "libR-sys", "src", "bindings.rs")
   if (!isTRUE(force) && isTRUE(file.exists(bindings_file))) {
-    message("libR bindings are already installed. Rerun with `force = TRUE` to force re-install.")
+    ui_i("libR bindings are already installed. Rerun with `force = TRUE` to force re-install.")
     return(invisible())
   }
 

--- a/R/knitr_engine.R
+++ b/R/knitr_engine.R
@@ -44,7 +44,7 @@ eng_impl <- function(options, rextendr_fun) {
   if (!is.environment(opts$env)) opts$env <- knitr::knit_global() # default env is knit_global()
 
   if (isTRUE(options$eval)) {
-    message('Evaluating Rust extendr code chunk...')
+    ui_v('Evaluating Rust extendr code chunk...')
     out <- utils::capture.output({
       result <- withVisible(
         do.call(rextendr_fun, c(list(code = code), opts))

--- a/R/knitr_engine.R
+++ b/R/knitr_engine.R
@@ -20,7 +20,7 @@ eng_extendrsrc <- function(options) {
 
 eng_impl <- function(options, rextendr_fun) {
   if (!requireNamespace("knitr", quietly = TRUE)) {
-    stop("The knitr package is required to run the extendr chunk engine.", call. = TRUE)
+    ui_throw("The knitr package is required to run the extendr chunk engine.")
   }
 
   if (!is.null(options$preamble)) {

--- a/R/register_extendr.R
+++ b/R/register_extendr.R
@@ -37,8 +37,8 @@ register_extendr <- function(path = ".", quiet = FALSE, force = FALSE, compile =
     ui_throw(
       "Unable to register the extendr module.",
       c(
-        bullet("x", "Could not find file {.file src/entrypoint.c }."),
-        bullet("o", "Are you sure this package is using extendr Rust code?")
+        bullet_x("Could not find file {.file src/entrypoint.c }."),
+        bullet_o("Are you sure this package is using extendr Rust code?")
       )
     )
   }
@@ -74,7 +74,7 @@ register_extendr <- function(path = ".", quiet = FALSE, force = FALSE, compile =
       # If compile wasn't invoked, it might succeed with explicit "compile = TRUE"
       ui_throw(
         msg,
-        bullet("i", "You need to compile first, try {.code register_rextendr(compile = TRUE)}.")
+        bullet_i("You need to compile first, try {.code register_rextendr(compile = TRUE)}.")
       )
     }
   }
@@ -104,7 +104,7 @@ register_extendr <- function(path = ".", quiet = FALSE, force = FALSE, compile =
     error = function(e) {
       ui_throw(
         "Failed to generate wrapper functions.",
-        bullet("x", e[["message"]])
+        bullet_x(e[["message"]])
       )
     }
   )

--- a/R/register_extendr.R
+++ b/R/register_extendr.R
@@ -38,7 +38,7 @@ register_extendr <- function(path = ".", quiet = FALSE, force = FALSE, compile =
       "Unable to register the extendr module.",
       c(
         ui_x("Could not find file {.file src/entrypoint.c }."),
-        ui_q("Are you sure this package is using extendr Rust code?")
+        ui_o("Are you sure this package is using extendr Rust code?")
       )
     )
   }

--- a/R/register_extendr.R
+++ b/R/register_extendr.R
@@ -29,7 +29,7 @@ register_extendr <- function(path = ".", quiet = FALSE, force = FALSE, compile =
   pkg_name <- x$get("Package")
 
   if (!isTRUE(quiet)) {
-    cli::cli_alert_info("Generating extendr wrapper functions for package: {.pkg {pkg_name}}.")
+    ui_i("Generating extendr wrapper functions for package: {.pkg {pkg_name}}.")
   }
 
   entrypoint_c_file <- rprojroot::find_package_root_file("src", "entrypoint.c", path = path)
@@ -85,7 +85,7 @@ register_extendr <- function(path = ".", quiet = FALSE, force = FALSE, compile =
   # wrapper file by hand) so the user might need to run with `force = TRUE`.
   if (!isTRUE(force) && length(find_newer_files_than(outfile, library_path)) > 0) {
     rel_path <- pretty_rel_path(outfile, path)
-    cli::cli_alert_info("{.file {rel_path}} is up-to-date. Skip generating wrapper functions.")
+    ui_i("{.file {rel_path}} is up-to-date. Skip generating wrapper functions.")
 
     return(invisible(character(0L)))
   }

--- a/R/register_extendr.R
+++ b/R/register_extendr.R
@@ -37,8 +37,8 @@ register_extendr <- function(path = ".", quiet = FALSE, force = FALSE, compile =
     ui_throw(
       "Unable to register the extendr module.",
       c(
-        ui_x("Could not find file {.file src/entrypoint.c }."),
-        ui_o("Are you sure this package is using extendr Rust code?")
+        bullet("x", "Could not find file {.file src/entrypoint.c }."),
+        bullet("o", "Are you sure this package is using extendr Rust code?")
       )
     )
   }
@@ -74,7 +74,7 @@ register_extendr <- function(path = ".", quiet = FALSE, force = FALSE, compile =
       # If compile wasn't invoked, it might succeed with explicit "compile = TRUE"
       ui_throw(
         msg,
-        ui_i("You need to compile first, try {.code register_rextendr(compile = TRUE)}.")
+        bullet("i", "You need to compile first, try {.code register_rextendr(compile = TRUE)}.")
       )
     }
   }
@@ -104,7 +104,7 @@ register_extendr <- function(path = ".", quiet = FALSE, force = FALSE, compile =
     error = function(e) {
       ui_throw(
         "Failed to generate wrapper functions.",
-        ui_x(e[["message"]])
+        bullet("x", e[["message"]])
       )
     }
   )

--- a/R/rextendr_document.R
+++ b/R/rextendr_document.R
@@ -8,7 +8,7 @@
 #' up-to-date R wrappers are generated before re-generating the package documentation.
 #' @inheritParams devtools::document
 #' @export
-document <- function(pkg = ".", quiet = FALSE, roclets = NULL) {
+document <- function(pkg = ".", quiet = getOption("usethis.quiet", FALSE), roclets = NULL) {
   try_save_all(quiet = quiet)
 
   register_extendr(path = pkg, quiet = quiet)

--- a/R/source.R
+++ b/R/source.R
@@ -120,7 +120,7 @@ rust_source <- function(file, code = NULL,
 
   dir <- get_build_dir(cache_build)
   if (!isTRUE(quiet)) {
-    message(sprintf("build directory: %s\n", dir))
+    ui_i(glue::glue("build directory: {dir}"))
     stdout <- "" # to be used by `system2()` below
   } else {
     stdout <- NULL

--- a/R/source.R
+++ b/R/source.R
@@ -114,7 +114,7 @@ rust_source <- function(file, code = NULL,
   if (is.null(extendr_deps)) {
     ui_throw(
       "Invalid argument.",
-      bullet("x", "`extendr_deps` cannot be `NULL`.")
+      bullet_x("`extendr_deps` cannot be `NULL`.")
     )
   }
 

--- a/R/source.R
+++ b/R/source.R
@@ -112,9 +112,9 @@ rust_source <- function(file, code = NULL,
                         use_rtools = TRUE) {
   profile <- match.arg(profile)
   if (is.null(extendr_deps)) {
-    stop(
-      "Invalid argument.\n  x `extendr_deps` cannot be `NULL`.",
-      call. = FALSE
+    ui_throw(
+      "Invalid argument.",
+      bullet("x", "`extendr_deps` cannot be `NULL`.")
     )
   }
 
@@ -258,7 +258,7 @@ invoke_cargo <- function(toolchain, specific_target, dir, profile,
     stderr = stdout
   )
   if (status != 0L) {
-    stop("Rust code could not be compiled successfully. Aborting.", call. = FALSE)
+    ui_throw("Rust code could not be compiled successfully. Aborting.")
   }
 }
 
@@ -316,7 +316,7 @@ get_specific_target_name <- function() {
       return("i686-pc-windows-gnu")
     }
 
-    stop("Unknown Windows architecture", call. = FALSE)
+    ui_throw("Unknown Windows architecture")
   }
 
   return(NULL)

--- a/R/source.R
+++ b/R/source.R
@@ -120,7 +120,7 @@ rust_source <- function(file, code = NULL,
 
   dir <- get_build_dir(cache_build)
   if (!isTRUE(quiet)) {
-    ui_i(glue::glue("build directory: {dir}"))
+    ui_i("build directory: {.file {dir}}")
     stdout <- "" # to be used by `system2()` below
   } else {
     stdout <- NULL

--- a/R/toml_serialization.R
+++ b/R/toml_serialization.R
@@ -44,15 +44,12 @@ to_toml <- function(...,
   invalid <- which(map_lgl(args, ~ is_atomic(.x) && !is.null(.x)))
   # If such args found, display an error message
   if (length(invalid) > 0) {
-    stop(
-      glue(
-        get_toml_err_msg(),
+    ui_throw(
+      get_toml_err_msg(),
+      c(
         make_idx_msg(invalid),
-        "i All top-level values should be named.",
-        .sep = "\n  ",
-        .trim = FALSE
-      ),
-      call. = FALSE
+        bullet("i", "All top-level values should be named.")
+      )
     )
   }
 
@@ -94,7 +91,7 @@ make_idx_msg <- function(invalid, args_limit = 5L) {
     idx <- glue("{idx}, ... ")
   }
 
-  glue("x Unnamed arguments found at position(s): {idx}.")
+  bullet("x", "Unnamed arguments found at position(s): {idx}.")
 }
 get_toml_err_msg <- function() "Object cannot be serialzied."
 get_toml_missing_msg <- function() {
@@ -117,14 +114,9 @@ simplify_row <- function(row) {
 format_toml <- function(x, ..., .top_level = FALSE) UseMethod("format_toml")
 
 format_toml.default <- function(x, ..., .top_level = FALSE) {
-  stop(
-    glue(
-      get_toml_err_msg(),
-      "x `{typeof(x)}` cannot be converted to toml.",
-      .sep = "\n  ",
-      .trim = FALSE
-    ),
-    call. = FALSE
+  ui_throw(
+    get_toml_err_msg(),
+    bullet("x", "`{typeof(x)}` cannot be converted to toml.")
   )
 }
 
@@ -174,14 +166,7 @@ format_toml.name <- function(x, ..., .top_level = FALSE) {
     }
   } else {
     if (is_missing(x)) {
-      stop(
-        glue(
-          get_toml_err_msg(),
-          get_toml_missing_msg(),
-          .sep = "\n  "
-        ),
-        call. = FALSE
-      )
+      ui_throw(get_toml_err_msg(), get_toml_missing_msg())
     } else {
       # This function errors and does not return
       format_toml.default(x, ..., .top_level = .top_level)
@@ -194,14 +179,7 @@ format_toml.NULL <- function(x, ..., .top_level = FALSE) {
   if (isTRUE(.top_level)) {
     return(character(0))
   } else {
-    stop(
-      paste(
-        get_toml_err_msg(),
-        get_toml_missing_msg(),
-        sep = "\n  "
-      ),
-      call. = FALSE
-    )
+    ui_throw(get_toml_err_msg(), get_toml_missing_msg())
   }
 }
 
@@ -286,15 +264,12 @@ format_toml.list <- function(x, ..., .top_level = FALSE) {
   names <- names2(x)
   invalid <- which(!nzchar(names))
   if (length(invalid) > 0) {
-    stop(
-      glue(
-        get_toml_err_msg(),
+    ui_throw(
+      get_toml_err_msg(),
+      c(
         make_idx_msg(invalid),
-        "i List values should have names.",
-        .sep = "\n  ",
-        .trim = FALSE
-      ),
-      call. = FALSE
+        bullet("i", "List values should have names.")
+      )
     )
   }
   result <- map2(names, x, function(nm, val) {

--- a/R/toml_serialization.R
+++ b/R/toml_serialization.R
@@ -48,7 +48,7 @@ to_toml <- function(...,
       get_toml_err_msg(),
       c(
         make_idx_msg(invalid),
-        bullet("i", "All top-level values should be named.")
+        bullet_i("All top-level values should be named.")
       )
     )
   }
@@ -91,7 +91,7 @@ make_idx_msg <- function(invalid, args_limit = 5L) {
     idx <- glue("{idx}, ... ")
   }
 
-  bullet("x", "Unnamed arguments found at position(s): {idx}.")
+  bullet_x("Unnamed arguments found at position(s): {idx}.")
 }
 get_toml_err_msg <- function() "Object cannot be serialzied."
 get_toml_missing_msg <- function() {
@@ -116,7 +116,7 @@ format_toml <- function(x, ..., .top_level = FALSE) UseMethod("format_toml")
 format_toml.default <- function(x, ..., .top_level = FALSE) {
   ui_throw(
     get_toml_err_msg(),
-    bullet("x", "`{typeof(x)}` cannot be converted to toml.")
+    bullet_x("`{typeof(x)}` cannot be converted to toml.")
   )
 }
 
@@ -268,7 +268,7 @@ format_toml.list <- function(x, ..., .top_level = FALSE) {
       get_toml_err_msg(),
       c(
         make_idx_msg(invalid),
-        bullet("i", "List values should have names.")
+        bullet_i("List values should have names.")
       )
     )
   }

--- a/R/track_rust_source.R
+++ b/R/track_rust_source.R
@@ -199,17 +199,17 @@ find_newer_files_than <- function(files, reference) {
   error_details <- character(0)
 
   if (length(reference) != 1L) {
-    error_details <- bullet("x", "Expected vector of length {.var 1}, got {.var {length(reference)}}.")
+    error_details <- bullet_x("Expected vector of length {.var 1}, got {.var {length(reference)}}.")
   }
 
   if (typeof(reference) != "character") {
-    error_details <- c(error_details, bullet("x", "Expected type {.var character}, got {.var {typeof(reference)}}."))
+    error_details <- c(error_details, bullet_x("Expected type {.var character}, got {.var {typeof(reference)}}."))
   }
 
   # if `reference` is already found invalid, skip checking the existence
   # Here we want path, i.e the value of `reference`.
   if (length(error_details) == 0L && !file.exists(reference)) {
-    error_details <- bullet("x", "File {.file {reference}} doesn't exist.")
+    error_details <- bullet_x("File {.file {reference}} doesn't exist.")
   }
 
   if (length(error_details) > 0L) {

--- a/R/track_rust_source.R
+++ b/R/track_rust_source.R
@@ -134,7 +134,7 @@ get_rust_files <- function(path = ".") {
 #'   or verbose (`FALSE`).
 #' @returns Logical `TRUE` if Rust source has been modified, `FALSE` otherwise.
 #' @noRd
-needs_compilation <- function(path = ".", quiet = FALSE) {
+needs_compilation <- function(path = ".", quiet = getOption("usethis.quiet", FALSE)) {
   library_path <- get_library_path(path)
 
   # This will likely never happen.

--- a/R/track_rust_source.R
+++ b/R/track_rust_source.R
@@ -199,17 +199,17 @@ find_newer_files_than <- function(files, reference) {
   error_details <- character(0)
 
   if (length(reference) != 1L) {
-    error_details <- ui_x("Expected vector of length {.var 1}, got {.var {length(reference)}}.")
+    error_details <- bullet("x", "Expected vector of length {.var 1}, got {.var {length(reference)}}.")
   }
 
   if (typeof(reference) != "character") {
-    error_details <- c(error_details, ui_x("Expected type {.var character}, got {.var {typeof(reference)}}."))
+    error_details <- c(error_details, bullet("x", "Expected type {.var character}, got {.var {typeof(reference)}}."))
   }
 
   # if `reference` is already found invalid, skip checking the existence
   # Here we want path, i.e the value of `reference`.
   if (length(error_details) == 0L && !file.exists(reference)) {
-    error_details <- ui_x("File {.file {reference}} doesn't exist.")
+    error_details <- bullet("x", "File {.file {reference}} doesn't exist.")
   }
 
   if (length(error_details) > 0L) {

--- a/R/track_rust_source.R
+++ b/R/track_rust_source.R
@@ -100,7 +100,7 @@ get_rust_files <- function(path = ".") {
   src_root <- rprojroot::find_package_root_file("src", path = path)
   if (!dir.exists(src_root)) {
     # No source code found
-    cli::cli_alert_warning("{.file src} directory is missing. Are you sure the package is set up to use Rust?")
+    ui_w("{.file src} directory is missing. Are you sure the package is set up to use Rust?")
     return(character(0))
   }
 
@@ -142,7 +142,7 @@ needs_compilation <- function(path = ".", quiet = FALSE) {
   if (!file.exists(library_path)) {
     if (!isTRUE(quiet)) {
       library_path_rel <- pretty_rel_path(library_path, path)
-      cli::cli_alert_warning("No library found at {.file {library_path_rel}}, recompilation is required.")
+      ui_w("No library found at {.file {library_path_rel}}, recompilation is required.")
     }
     return(TRUE)
   }
@@ -162,7 +162,7 @@ needs_compilation <- function(path = ".", quiet = FALSE) {
   if (!isTRUE(quiet)) {
     purrr::walk(
       pretty_rel_path(modified_files_paths, search_from = path),
-      ~ cli::cli_alert_info("File {.file {.x}} has been modified since last compilation.")
+      ~ ui_i("File {.file {.x}} has been modified since last compilation.")
     )
   }
 

--- a/R/try_save_all.R
+++ b/R/try_save_all.R
@@ -9,7 +9,7 @@ try_save_all <- function(quiet = FALSE) {
   if (requireNamespace("rstudioapi", quietly = TRUE) && rstudioapi::hasFun("documentSaveAll")) {
     rstudioapi::documentSaveAll()
     if (!isTRUE(quiet)) {
-      cli::cli_alert_success("Saving changes in the open files.")
+      ui_v("Saving changes in the open files.")
     }
   }
 }

--- a/R/ui.R
+++ b/R/ui.R
@@ -94,7 +94,7 @@ ui_w <- function(text = "", env = parent.frame()) {
 #' }
 #' @noRd
 ui_throw <- function(message = "Internal error", details = character(0), env = parent.frame()) {
-  message <- cli::cli_format_method(cli::cli_text(message, .envir = env))
+  message <- cli_format_text(message, env = env)
 
   if (length(details) != 0L) {
     details <- glue::glue_collapse(details, sep = "\n")
@@ -102,4 +102,9 @@ ui_throw <- function(message = "Internal error", details = character(0), env = p
   }
 
   rlang::abort(message, class = "rextendr_error")
+}
+
+
+cli_format_text <- function(message, env = parent.frame()) {
+  cli::cli_format_method(cli::cli_text(message, .envir = env))
 }

--- a/R/ui.R
+++ b/R/ui.R
@@ -104,7 +104,6 @@ ui_throw <- function(message = "Internal error", details = character(0), env = p
   rlang::abort(message, class = "rextendr_error")
 }
 
-
 cli_format_text <- function(message, env = parent.frame()) {
   cli::cli_format_method(cli::cli_text(message, .envir = env))
 }

--- a/R/ui.R
+++ b/R/ui.R
@@ -1,23 +1,33 @@
-bullet <- function(type = c("x", "i", "v", "o", "w"), text = "", env = parent.frame()) {
-  type <- match.arg(type)
-  cli_f <- switch(
-    type,
-    x = cli::cli_alert_danger,
-    i = cli::cli_alert_info,
-    v = cli::cli_alert_success,
-    o = cli::cli_ul,
-    w = cli::cli_alert_warning
-  )
-
+bullet <- function(text = "", cli_f = cli::cli_alert_success, env = parent.frame()) {
   cli::cli_format_method(cli_f(text, .envir = env))
 }
 
-ui_bullet <- function(type, text, env = parent.frame()) {
+bullet_x <- function(text = "", env = parent.frame()) {
+  bullet(text, cli::cli_alert_danger, env = env)
+}
+
+bullet_i <- function(text = "", env = parent.frame()) {
+  bullet(text, cli::cli_alert_info, env = env)
+}
+
+bullet_v <- function(text = "", env = parent.frame()) {
+  bullet(text, cli::cli_alert_success, env = env)
+}
+
+bullet_o <- function(text = "", env = parent.frame()) {
+  bullet(text, cli::cli_ul, env = env)
+}
+
+bullet_w <- function(text = "", env = parent.frame()) {
+  bullet(text, cli::cli_alert_warning, env = env)
+}
+
+ui_bullet <- function(text) {
   if (getOption("usethis.quiet", FALSE)) {
     return(invisible())
   }
 
-  rlang::inform(bullet(type, text, env = env))
+  rlang::inform(text)
 }
 
 #' Formats text as an error message.
@@ -27,7 +37,7 @@ ui_bullet <- function(type, text, env = parent.frame()) {
 #' @param text String to format.
 #' @noRd
 ui_x <- function(text = "", env = parent.frame()) {
-  ui_bullet("x", text, env = env)
+  ui_bullet(bullet_x(text, env = env))
 }
 
 #' Formats text as an information message.
@@ -37,7 +47,7 @@ ui_x <- function(text = "", env = parent.frame()) {
 #' @inheritParams ui_x
 #' @noRd
 ui_i <- function(text = "", env = parent.frame()) {
-  ui_bullet("i", text, env = env)
+  ui_bullet(bullet_i(text, env = env))
 }
 
 #' Formats text as a success message.
@@ -47,7 +57,7 @@ ui_i <- function(text = "", env = parent.frame()) {
 #' @inheritParams ui_x
 #' @noRd
 ui_v <- function(text = "", env = parent.frame()) {
-  ui_bullet("v", text, env = env)
+  ui_bullet(bullet_v(text, env = env))
 }
 
 #' Formats text as a bullet point
@@ -57,7 +67,7 @@ ui_v <- function(text = "", env = parent.frame()) {
 #' @inheritParams ui_x
 #' @noRd
 ui_o <- function(text = "", env = parent.frame()) {
-  ui_bullet("o", text, env = env)
+  ui_bullet(bullet_o(text, env = env))
 }
 
 #' Formats text as a warning message.
@@ -67,7 +77,7 @@ ui_o <- function(text = "", env = parent.frame()) {
 #' @inheritParams ui_x
 #' @noRd
 ui_w <- function(text = "", env = parent.frame()) {
-  ui_bullet("w", text, env = env)
+  ui_bullet(bullet_w(text, env = env))
 }
 
 #' Throws an error with formatted message.
@@ -82,9 +92,9 @@ ui_w <- function(text = "", env = parent.frame()) {
 #' ui_throw(
 #'   "Something bad has happened!",
 #'   c(
-#'     bullet("x", "This thing happened."),
-#'     bullet("x", "That thing happened."),
-#'     bullet("o", "Are you sure you did it right?")
+#'     bullet_x("This thing happened."),
+#'     bullet_x("That thing happened."),
+#'     bullet_o("Are you sure you did it right?")
 #'   )
 #' )
 #' # Error: Something bad has happened!

--- a/R/ui.R
+++ b/R/ui.R
@@ -1,4 +1,4 @@
-bullet <- function(type = c("x", "i", "v", "o", "w"), text = "") {
+bullet <- function(type = c("x", "i", "v", "o", "w"), text = "", env = parent.frame()) {
   type <- match.arg(type)
   cli_f <- switch(
     type,
@@ -9,15 +9,15 @@ bullet <- function(type = c("x", "i", "v", "o", "w"), text = "") {
     w = cli::cli_alert_warning
   )
 
-  cli::cli_format_method(cli_f(text))
+  cli::cli_format_method(cli_f(text, .envir = env))
 }
 
-ui_bullet <- function(type, text) {
+ui_bullet <- function(type, text, env = parent.frame()) {
   if (getOption("usethis.quiet", FALSE)) {
     return(invisible())
   }
 
-  rlang::inform(bullet(type, text))
+  rlang::inform(bullet(type, text, env = env))
 }
 
 #' Formats text as an error message.
@@ -26,8 +26,8 @@ ui_bullet <- function(type, text) {
 #' Supports {cli}'s inline styles and string interpolation.
 #' @param text String to format.
 #' @noRd
-ui_x <- function(text = "") {
-  ui_bullet("x", text)
+ui_x <- function(text = "", env = parent.frame()) {
+  ui_bullet("x", text, env = env)
 }
 
 #' Formats text as an information message.
@@ -36,8 +36,8 @@ ui_x <- function(text = "") {
 #' Supports {cli}'s inline styles and string interpolation.
 #' @inheritParams ui_x
 #' @noRd
-ui_i <- function(text = "") {
-  ui_bullet("i", text)
+ui_i <- function(text = "", env = parent.frame()) {
+  ui_bullet("i", text, env = env)
 }
 
 #' Formats text as a success message.
@@ -46,8 +46,8 @@ ui_i <- function(text = "") {
 #' Supports {cli}'s inline styles and string interpolation.
 #' @inheritParams ui_x
 #' @noRd
-ui_v <- function(text = "") {
-  ui_bullet("v", text)
+ui_v <- function(text = "", env = parent.frame()) {
+  ui_bullet("v", text, env = env)
 }
 
 #' Formats text as a bullet point
@@ -56,8 +56,8 @@ ui_v <- function(text = "") {
 #' Supports {cli}'s inline styles and string interpolation.
 #' @inheritParams ui_x
 #' @noRd
-ui_o <- function(text = "") {
-  ui_bullet("o", text)
+ui_o <- function(text = "", env = parent.frame()) {
+  ui_bullet("o", text, env = env)
 }
 
 #' Formats text as a warning message.
@@ -66,8 +66,8 @@ ui_o <- function(text = "") {
 #' Supports {cli}'s inline styles and string interpolation.
 #' @inheritParams ui_x
 #' @noRd
-ui_w <- function(text = "") {
-  ui_bullet("w", text)
+ui_w <- function(text = "", env = parent.frame()) {
+  ui_bullet("w", text, env = env)
 }
 
 #' Throws an error with formatted message.
@@ -93,8 +93,8 @@ ui_w <- function(text = "") {
 #' # o Are you sure you did it right?
 #' }
 #' @noRd
-ui_throw <- function(message = "Internal error", details = character(0)) {
-  message <- cli::cli_format_method(cli::cli_text(message))
+ui_throw <- function(message = "Internal error", details = character(0), env = parent.frame()) {
+  message <- cli::cli_format_method(cli::cli_text(message, .envir = env))
 
   if (length(details) != 0L) {
     details <- glue::glue_collapse(details, sep = "\n")

--- a/R/ui.R
+++ b/R/ui.R
@@ -91,12 +91,8 @@ ui_w <- function(text = "") {
 #' # o Are you sure you did it right?
 #' }
 #' @noRd
-ui_throw <- function(message, details = character(0)) {
-  if (missing(message) || !nzchar(message)) {
-    message <- "Internal error"
-  } else {
-    message <- cli::cli_format_method(cli::cli_text(message))
-  }
+ui_throw <- function(message = "Internal error", details = character(0)) {
+  message <- cli::cli_format_method(cli::cli_text(message))
 
   if (length(details) != 0L) {
     details <- glue::glue_collapse(details, sep = "\n")

--- a/R/ui.R
+++ b/R/ui.R
@@ -99,5 +99,5 @@ ui_throw <- function(message = "Internal error", details = character(0)) {
     message <- glue::glue(message, details, .sep = "\n")
   }
 
-  rlang::abort(message, call. = FALSE, class = "rextendr_error")
+  rlang::abort(message, class = "rextendr_error")
 }

--- a/R/ui.R
+++ b/R/ui.R
@@ -82,9 +82,9 @@ ui_w <- function(text = "", env = parent.frame()) {
 #' ui_throw(
 #'   "Something bad has happened!",
 #'   c(
-#'     bullet("This thing happened.", "x"),
-#'     bullet("That thing happened.", "x"),
-#'     bullet("Are you sure you did it right?", "o")
+#'     bullet("x", "This thing happened."),
+#'     bullet("x", "That thing happened."),
+#'     bullet("o", "Are you sure you did it right?")
 #'   )
 #' )
 #' # Error: Something bad has happened!

--- a/R/ui.R
+++ b/R/ui.R
@@ -73,10 +73,10 @@ ui_w <- function(text = "") {
 #' Throws an error with formatted message.
 #'
 #' Creates a styled error message that is then thrown
-#' using [`stop()`]. Supports {cli} formatting.
+#' using [`rlang::abort()`]. Supports {cli} formatting.
 #' @param message The primary error message.
 #' @param details An optional character vector of error detais.
-#' can be formatted with `ui_*` helper functions.
+#' can be formatted with `bullet()`.
 #' @examples
 #' \dontrun{
 #' ui_throw(

--- a/R/ui.R
+++ b/R/ui.R
@@ -5,6 +5,10 @@
 #' @param text String to format.
 #' @noRd
 ui_x <- function(text = "") {
+  if (getOption("usethis.quiet", FALSE)) {
+    return(invisible())
+  }
+
   cli::cli_format_method(cli::cli_alert_danger(text))
 }
 
@@ -15,6 +19,10 @@ ui_x <- function(text = "") {
 #' @inheritParams ui_x
 #' @noRd
 ui_i <- function(text = "") {
+  if (getOption("usethis.quiet", FALSE)) {
+    return(invisible())
+  }
+
   cli::cli_format_method(cli::cli_alert_info(text))
 }
 
@@ -25,29 +33,25 @@ ui_i <- function(text = "") {
 #' @inheritParams ui_x
 #' @noRd
 ui_v <- function(text = "") {
+  if (getOption("usethis.quiet", FALSE)) {
+    return(invisible())
+  }
+
   cli::cli_format_method(cli::cli_alert_success(text))
 }
 
-#' Formats text as a question message.
+#' Formats text as a bullet point
 #'
-#' Prepends `text` with yellow question mark (`?`).
+#' Prepends `text` with red bullet point
 #' Supports {cli}'s inline styles and string interpolation.
 #' @inheritParams ui_x
 #' @noRd
-ui_q <- function(text = "") {
-  # There is no built-in style for questioning message,
-  # so we construct it ourselves.
-  # This will not be affected by global styling.
-  cli::cli_format_method(
-    cli::cli_alert(
-      paste(
-        cli::col_yellow("?"),
-        cli::cli_format_method(
-          cli::cli_text(text)
-        )
-      )
-    )
-  )
+ui_o <- function(text = "") {
+  if (getOption("usethis.quiet", FALSE)) {
+    return(invisible())
+  }
+
+  cli::cli_format_method(cli::cli_ul(text))
 }
 
 #' Formats text as a warning message.
@@ -57,6 +61,10 @@ ui_q <- function(text = "") {
 #' @inheritParams ui_x
 #' @noRd
 ui_w <- function(text = "") {
+  if (getOption("usethis.quiet", FALSE)) {
+    return(invisible())
+  }
+
   cli::cli_format_method(cli::cli_alert_warning(text))
 }
 
@@ -74,7 +82,7 @@ ui_w <- function(text = "") {
 #'   c(
 #'     ui_x("This thing happened."),
 #'     ui_x("That thing happened."),
-#'     ui_q("Are you sure you did it right?")
+#'     ui_o("Are you sure you did it right?")
 #'   )
 #' )
 #' # Error: Something bad has happened!

--- a/R/ui.R
+++ b/R/ui.R
@@ -93,25 +93,15 @@ ui_w <- function(text = "") {
 #' @noRd
 ui_throw <- function(message, details = character(0)) {
   if (missing(message) || !nzchar(message)) {
-    message <- "Internal error."
+    message <- "Internal error"
   } else {
     message <- cli::cli_format_method(cli::cli_text(message))
   }
 
   if (length(details) != 0L) {
-    details <- glue::glue_collapse(
-      details,
-      sep = "\n"
-    )
-    stop(
-      glue::glue(
-        message,
-        details,
-        .sep = "\n"
-      ),
-      call. = FALSE
-    )
-  } else {
-    stop(message, call. = FALSE)
+    details <- glue::glue_collapse(details, sep = "\n")
+    message <- glue::glue(message, details, .sep = "\n")
   }
+
+  rlang::abort(message, call. = FALSE, class = "rextendr_error")
 }

--- a/R/ui.R
+++ b/R/ui.R
@@ -1,3 +1,25 @@
+bullet <- function(type = c("x", "i", "v", "o", "w"), text = "") {
+  type <- match.arg(type)
+  cli_f <- switch(
+    type,
+    x = cli::cli_alert_danger,
+    i = cli::cli_alert_info,
+    v = cli::cli_alert_success,
+    o = cli::cli_ul,
+    w = cli::cli_alert_warning
+  )
+
+  cli::cli_format_method(cli_f(text))
+}
+
+ui_bullet <- function(type, text) {
+  if (getOption("usethis.quiet", FALSE)) {
+    return(invisible())
+  }
+
+  rlang::inform(bullet(type, text))
+}
+
 #' Formats text as an error message.
 #'
 #' Prepends `text` with red cross (`x`).
@@ -5,11 +27,7 @@
 #' @param text String to format.
 #' @noRd
 ui_x <- function(text = "") {
-  if (getOption("usethis.quiet", FALSE)) {
-    return(invisible())
-  }
-
-  cli::cli_format_method(cli::cli_alert_danger(text))
+  ui_bullet("x", text)
 }
 
 #' Formats text as an information message.
@@ -19,11 +37,7 @@ ui_x <- function(text = "") {
 #' @inheritParams ui_x
 #' @noRd
 ui_i <- function(text = "") {
-  if (getOption("usethis.quiet", FALSE)) {
-    return(invisible())
-  }
-
-  cli::cli_format_method(cli::cli_alert_info(text))
+  ui_bullet("i", text)
 }
 
 #' Formats text as a success message.
@@ -33,11 +47,7 @@ ui_i <- function(text = "") {
 #' @inheritParams ui_x
 #' @noRd
 ui_v <- function(text = "") {
-  if (getOption("usethis.quiet", FALSE)) {
-    return(invisible())
-  }
-
-  cli::cli_format_method(cli::cli_alert_success(text))
+  ui_bullet("v", text)
 }
 
 #' Formats text as a bullet point
@@ -47,11 +57,7 @@ ui_v <- function(text = "") {
 #' @inheritParams ui_x
 #' @noRd
 ui_o <- function(text = "") {
-  if (getOption("usethis.quiet", FALSE)) {
-    return(invisible())
-  }
-
-  cli::cli_format_method(cli::cli_ul(text))
+  ui_bullet("o", text)
 }
 
 #' Formats text as a warning message.
@@ -61,11 +67,7 @@ ui_o <- function(text = "") {
 #' @inheritParams ui_x
 #' @noRd
 ui_w <- function(text = "") {
-  if (getOption("usethis.quiet", FALSE)) {
-    return(invisible())
-  }
-
-  cli::cli_format_method(cli::cli_alert_warning(text))
+  ui_bullet("w", text)
 }
 
 #' Throws an error with formatted message.
@@ -80,9 +82,9 @@ ui_w <- function(text = "") {
 #' ui_throw(
 #'   "Something bad has happened!",
 #'   c(
-#'     ui_x("This thing happened."),
-#'     ui_x("That thing happened."),
-#'     ui_o("Are you sure you did it right?")
+#'     bullet("This thing happened.", "x"),
+#'     bullet("That thing happened.", "x"),
+#'     bullet("Are you sure you did it right?", "o")
 #'   )
 #' )
 #' # Error: Something bad has happened!

--- a/R/ui.R
+++ b/R/ui.R
@@ -88,7 +88,7 @@ ui_w <- function(text = "") {
 #' # Error: Something bad has happened!
 #' # x This thing happened.
 #' # x That thing happened.
-#' # ? Are you sure you did it right?
+#' # o Are you sure you did it right?
 #' }
 #' @noRd
 ui_throw <- function(message, details = character(0)) {

--- a/R/use_extendr.R
+++ b/R/use_extendr.R
@@ -15,7 +15,7 @@
 #' @return A logical value (invisible) indicating whether any package files were
 #' generated or not.
 #' @export
-use_extendr <- function(path = ".", quiet = FALSE) {
+use_extendr <- function(path = ".", quiet = getOption("usethis.quiet", FALSE)) {
   x <- desc::desc(rprojroot::find_package_root_file("DESCRIPTION", path = path))
   pkg_name <- x$get("Package")
 
@@ -24,20 +24,20 @@ use_extendr <- function(path = ".", quiet = FALSE) {
 
   if (dir.exists(src_dir)) {
     if (!isTRUE(quiet)) {
-      cli::cli_alert_danger("Directory {.file src} already present in package source. No action taken.")
+      ui_x("Directory {.file src} already present in package source. No action taken.")
     }
     return(invisible(FALSE))
   }
   if (file.exists(wrappers_file)) {
     if (!isTRUE(quiet)) {
-      cli::cli_alert_danger("File {.file R/extendr-wrappers.R} already present in package source. No action taken.")
+      ui_x("File {.file R/extendr-wrappers.R} already present in package source. No action taken.")
     }
     return(invisible(FALSE))
   }
 
   rust_src_dir <- file.path(src_dir, "rust", "src")
   dir.create(rust_src_dir, recursive = TRUE)
-  cli::cli_alert_success("Creating {.file {pretty_rel_path(rust_src_dir, path)}}.")
+  ui_v("Creating {.file {pretty_rel_path(rust_src_dir, path)}}.")
 
   entrypoint_content <- glue(
     r"(
@@ -187,9 +187,9 @@ extendr_module! {{
   make_example_wrappers(pkg_name, wrappers_file, extra_items = example_function_wrapper, path = path)
 
   if (!isTRUE(quiet)) {
-    cli::cli_alert_success("Finished configuring {.pkg extendr} for package {.pkg {pkg_name}}.")
-    cli::cli_alert_warning("Please update the system requirement in {.file DESCRIPTION} file.")
-    cli::cli_alert_warning("Please run {.fun rextendr::document} for changes to take effect.")
+    ui_v("Finished configuring {.pkg extendr} for package {.pkg {pkg_name}}.")
+    ui_w("Please update the system requirement in {.file DESCRIPTION} file.")
+    ui_w("Please run {.fun rextendr::document} for changes to take effect.")
   }
 
   return(invisible(TRUE))
@@ -227,9 +227,9 @@ make_example_wrappers <- function(pkg_name, outfile, path = ".", extra_items = N
     )
   }
 
-  brio::write_lines(wrappers_content, outfile)
   if (!isTRUE(quiet)) {
     rel_path <- pretty_rel_path(outfile, search_from = path)
-    cli::cli_alert_success("Writing wrappers to {.file {rel_path}}.")
+    ui_v("Writing wrappers to {.file {rel_path}}.")
   }
+  brio::write_lines(wrappers_content, outfile)
 }

--- a/R/use_extendr.R
+++ b/R/use_extendr.R
@@ -11,7 +11,7 @@
 #'
 #' @param path File path to the package for which to generate wrapper code.
 #' @param quiet Logical indicating whether any progress messages should be
-#'   generated or not.
+#'   generated or not. Also checks the `usethis.quiet` option.
 #' @return A logical value (invisible) indicating whether any package files were
 #' generated or not.
 #' @export

--- a/R/write_file.R
+++ b/R/write_file.R
@@ -5,19 +5,19 @@
 #' controlled by the `quiet` parameter.
 #' @param text Character vector containing text to write.
 #' @param path A string giving the file path to write to.
-#' @param search_root_from This parameter only affects messages displayed to the user. 
+#' @param search_root_from This parameter only affects messages displayed to the user.
 #' It has no effect on where the file is written.
 #' It gets passed to [`pretty_rel_path()`] if `quiet = FALSE`.
 #' It is unused otherwise.
 #' @param quiet Logical scalar indicating whether the output should be quiet (`TRUE`)
-#'   or verbose (`FALSE`).
+#'   or verbose (`FALSE`). `quiet` also checks if `usethis.quiet` is set in options.
 #' @return The output of [`brio::write_lines()`] (invisibly).
 #' @noRd
-write_file <- function(text, path, search_root_from = ".", quiet = FALSE) {
+write_file <- function(text, path, search_root_from = ".", quiet = getOption("usethis.quiet", FALSE)) {
   output <- brio::write_lines(text = text, path = path)
   if (!isTRUE(quiet)) {
     rel_path <- pretty_rel_path(path, search_from = search_root_from)
-    cli::cli_alert_success("Writing file {.file {rel_path}}.")
+    ui_v("Writing file {.file {rel_path}}.")
   }
   invisible(output)
 }

--- a/man/document.Rd
+++ b/man/document.Rd
@@ -4,7 +4,7 @@
 \alias{document}
 \title{Compile Rust code and generate package documentation.}
 \usage{
-document(pkg = ".", quiet = FALSE, roclets = NULL)
+document(pkg = ".", quiet = getOption("usethis.quiet", FALSE), roclets = NULL)
 }
 \arguments{
 \item{pkg}{The package to use, can be a file path to the package or a

--- a/man/use_extendr.Rd
+++ b/man/use_extendr.Rd
@@ -4,13 +4,13 @@
 \alias{use_extendr}
 \title{Set up a package for use with Rust extendr code}
 \usage{
-use_extendr(path = ".", quiet = FALSE)
+use_extendr(path = ".", quiet = getOption("usethis.quiet", FALSE))
 }
 \arguments{
 \item{path}{File path to the package for which to generate wrapper code.}
 
 \item{quiet}{Logical indicating whether any progress messages should be
-generated or not.}
+generated or not. Also checks the \code{usethis.quiet} option.}
 }
 \value{
 A logical value (invisible) indicating whether any package files were

--- a/principles.md
+++ b/principles.md
@@ -8,7 +8,7 @@ rextendr uses the cli package to format messages to the user, which are generall
 
 | function | purpose                                                                                                       |
 |----------|---------------------------------------------------------------------------------------------------------------|
-| `ui_v()` | communicate that rextendr has done something, such as write a file                                            |
+| `ui_v()` | communicate that rextendr has done something successfully, such as write a file                               |
 | `ui_i()` | provide extra information to the user                                                                         |
 | `ui_w()` | warn the user about something (note: this is still condition of class `message`, not `warning`)               |
 | `ui_o()` | indicate that the user has something to do                                                                    |

--- a/principles.md
+++ b/principles.md
@@ -1,0 +1,37 @@
+# rextendr design prinicples
+
+This guide documents important internal coding conventions used in rextendr.
+
+## Communicating with the user
+
+rextendr uses the cli package to format messages to the user, which are generally then routed through `rlang::inform()`. Most UI will happen through `ui_*()` functions:
+
+| function | purpose                                                                                                       |
+|----------|---------------------------------------------------------------------------------------------------------------|
+| `ui_v()` | communicate that rextendr has done something, such as write a file                                            |
+| `ui_i()` | provide extra information to the user                                                                         |
+| `ui_w()` | warn the user about something (note: this is still condition of class `message`, not `warning`)               |
+| `ui_o()` | indicate that the user has something to do                                                                    |
+| `ui_x()` | tell the user that something has gone wrong (note: this still is a condition of class `message`, not `error`) |
+
+Each `ui_*()` function has a corresponding `bullet_*()` function that formats text to use in the message. 
+
+Because each `ui_*()` and `bullet_*()` function is processed through cli, they support [glue-based interpolation](https://cli.r-lib.org/articles/semantic-cli.html#interpolation) and [inline text formatting](https://cli.r-lib.org/articles/semantic-cli.html#inline-text-formatting).
+
+## Throwing and testing errors
+
+Pass all errors via `ui_throw()`. You can also add additional details via the `details` argument. This can be a good place to provide more information with `bullet_*()` functions, e.g.
+
+```r
+ui_throw(
+  "Unable to register the extendr module.",
+  details = c(
+    bullet_x("Could not find file {.file src/entrypoint.c }."),
+    bullet_o("Are you sure this package is using extendr Rust code?")
+  )
+)
+```
+
+`ui_throw()` emits an error of class `rextendr_error`. This makes it easier to know that an error is coming from rextendr. It also allows downstream users to catch and handle rextendr errors more easily with `tryCatch(..., rextender_error = function(re) ...)`
+
+To test for errors from rextendr, use `expect_rextendr_error()`

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -1,0 +1,3 @@
+expect_rextendr_error <- function(...) {
+  expect_error(..., class = "rextendr_error")
+}

--- a/tests/testthat/test-helper-functions.R
+++ b/tests/testthat/test-helper-functions.R
@@ -177,14 +177,14 @@ test_that("`ui_*` generate correct ansi strings", {
   # Simplified version of the generated message:
   # x This is an error in `package::function()`.
   msg_danger <- "This is an error in {.fun package::function}."
-  danger_rxr <- bullet("x", msg_danger)
+  danger_rxr <- bullet_x(msg_danger)
   danger_cli <- cli::cli_format_method(
     cli::cli_alert_danger(msg_danger)
   )
 
   # i Index out of bounds at `1`, `2`, `3`, `4`, and `5`,
   msg_info <- "Index out of bounds at {.val {1:5}}."
-  info_rxr <- bullet("i", msg_info)
+  info_rxr <- bullet_i(msg_info)
   info_cli <- cli::cli_format_method(
     cli::cli_alert_info(
       msg_info
@@ -193,21 +193,21 @@ test_that("`ui_*` generate correct ansi strings", {
 
   # ! File path/to/file.ext already exists.
   msg_warning <- "File {.file path/to/file.ext} already exists."
-  warning_rxr <- bullet("w", msg_warning)
+  warning_rxr <- bullet_w(msg_warning)
   warning_cli <- cli::cli_format_method(
     cli::cli_alert_warning(msg_warning)
   )
 
   # v Successfully updated pkg! Press [Y] to continue.
   msg_success <- "Successfully udpated {.pkg {.emph a.package}}! Press {.key Y} to continue."
-  success_rxr <- bullet("v", msg_success)
+  success_rxr <- bullet_v(msg_success)
   success_cli <- cli::cli_format_method(
     cli::cli_alert_success(msg_success)
   )
 
   # o Are you sure file DESCRIPTION exists?
   msg_question <- "Are you sure file {.path DESCRIPTION} exists?"
-  question_rxr <- bullet("o", msg_question)
+  question_rxr <- bullet_o(msg_question)
   question_cli <- cli::cli_format_method(
     cli::cli_ul(msg_question)
   )
@@ -256,10 +256,10 @@ test_that("`ui_throw()` formats error messages", {
     object = ui_throw(
       "Something bad has happened!",
       c(
-        bullet("x", "This bad thing happened."),
-        bullet("x", "That bad thing happened."),
-        bullet("w", "{.file File} does not exist."),
-        bullet("i", "Ensure {.val {21 + 21}} == {.val {21 * 2}}.")
+        bullet_x("This bad thing happened."),
+        bullet_x("That bad thing happened."),
+        bullet_w("{.file File} does not exist."),
+        bullet_i("Ensure {.val {21 + 21}} == {.val {21 * 2}}.")
       )
     ),
     # (Sub)string equal to the desired output

--- a/tests/testthat/test-helper-functions.R
+++ b/tests/testthat/test-helper-functions.R
@@ -164,8 +164,8 @@ test_that("find_newer_files_than() works", {
   expect_equal(find_newer_files_than(character(0), old_file), character(0))
   expect_equal(find_newer_files_than(NA_character_, old_file), character(0))
   # invalid cases
-  expect_error(find_newer_files_than(old_file, character(0)))
-  expect_error(find_newer_files_than(old_file, "/no/such/files"))
+  expect_rextendr_error(find_newer_files_than(old_file, character(0)))
+  expect_rextendr_error(find_newer_files_than(old_file, "/no/such/files"))
 })
 
 # Verifies that `ui_*` assemble correct ansi strings.
@@ -251,15 +251,15 @@ test_that("`ui_throw()` formats error messages", {
 
   expected <- paste(expected, collapse = "\n")
 
-  expect_error(
+  expect_rextendr_error(
     # Expresion we test
     object = ui_throw(
       "Something bad has happened!",
       c(
-        ui_x("This bad thing happened."),
-        ui_x("That bad thing happened."),
-        ui_w("{.file File} does not exist."),
-        ui_i("Ensure {.val {21 + 21}} == {.val {21 * 2}}.")
+        bullet("x", "This bad thing happened."),
+        bullet("x", "That bad thing happened."),
+        bullet("w", "{.file File} does not exist."),
+        bullet("i", "Ensure {.val {21 + 21}} == {.val {21 * 2}}.")
       )
     ),
     # (Sub)string equal to the desired output
@@ -295,18 +295,11 @@ test_that("`write_file()` does the same as `brio::write_lines()`", {
 
   # Writing using {brio} and {rextendr}
   brio::write_lines(text, temp_file_brio)
-  # `write_file()` produces a {cli} message, so it is captured here
-  ui_message <- cli::cli_format_method(write_file(text, temp_file_rxr))
+  # `write_file()` produces a {cli} message
+  expect_message(write_file(text, temp_file_rxr), "Writing file")
 
   # Verifies file content
   expect_equal(readLines(temp_file_rxr), readLines(temp_file_brio))
   # Obtaines 'relative path' that is displayed to the user.
   rel_path <- pretty_rel_path(temp_file_rxr, ".")
-  # Verifies displayed message
-  expect_equal(
-    ui_message,
-    cli::cli_format_method(
-      cli::cli_alert_success("Writing file {.file {rel_path}}.")
-    )
-  )
 })

--- a/tests/testthat/test-helper-functions.R
+++ b/tests/testthat/test-helper-functions.R
@@ -177,14 +177,14 @@ test_that("`ui_*` generate correct ansi strings", {
   # Simplified version of the generated message:
   # x This is an error in `package::function()`.
   msg_danger <- "This is an error in {.fun package::function}."
-  danger_rxr <- ui_x(msg_danger)
+  danger_rxr <- bullet("x", msg_danger)
   danger_cli <- cli::cli_format_method(
     cli::cli_alert_danger(msg_danger)
   )
 
   # i Index out of bounds at `1`, `2`, `3`, `4`, and `5`,
   msg_info <- "Index out of bounds at {.val {1:5}}."
-  info_rxr <- ui_i(msg_info)
+  info_rxr <- bullet("i", msg_info)
   info_cli <- cli::cli_format_method(
     cli::cli_alert_info(
       msg_info
@@ -193,21 +193,21 @@ test_that("`ui_*` generate correct ansi strings", {
 
   # ! File path/to/file.ext already exists.
   msg_warning <- "File {.file path/to/file.ext} already exists."
-  warning_rxr <- ui_w(msg_warning)
+  warning_rxr <- bullet("w", msg_warning)
   warning_cli <- cli::cli_format_method(
     cli::cli_alert_warning(msg_warning)
   )
 
   # v Successfully updated pkg! Press [Y] to continue.
   msg_success <- "Successfully udpated {.pkg {.emph a.package}}! Press {.key Y} to continue."
-  success_rxr <- ui_v(msg_success)
+  success_rxr <- bullet("v", msg_success)
   success_cli <- cli::cli_format_method(
     cli::cli_alert_success(msg_success)
   )
 
   # o Are you sure file DESCRIPTION exists?
   msg_question <- "Are you sure file {.path DESCRIPTION} exists?"
-  question_rxr <- ui_o(msg_question)
+  question_rxr <- bullet("o", msg_question)
   question_cli <- cli::cli_format_method(
     cli::cli_ul(msg_question)
   )

--- a/tests/testthat/test-helper-functions.R
+++ b/tests/testthat/test-helper-functions.R
@@ -205,15 +205,11 @@ test_that("`ui_*` generate correct ansi strings", {
     cli::cli_alert_success(msg_success)
   )
 
-  # ? Are you sure file DESCRIPTION exists?
+  # o Are you sure file DESCRIPTION exists?
   msg_question <- "Are you sure file {.path DESCRIPTION} exists?"
-  question_rxr <- ui_q(msg_question)
+  question_rxr <- ui_o(msg_question)
   question_cli <- cli::cli_format_method(
-    cli::cli_alert(
-      cli::cli_format_method(
-        cli::cli_text(cli::col_yellow("?"), " ", msg_question)
-      )
-    )
+    cli::cli_ul(msg_question)
   )
 
   expect_equal(danger_rxr, danger_cli)
@@ -278,9 +274,9 @@ test_that("`write_file()` does the same as `brio::write_lines()`", {
   # The initial text fragment is split into several lines.
   text <- stringi::stri_split_lines1(
     "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et
-    dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea 
-    commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat 
-    nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit 
+    dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+    commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat
+    nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit
     anim id est laborum."
   )
 

--- a/tests/testthat/test-make-module-macro.R
+++ b/tests/testthat/test-make-module-macro.R
@@ -62,10 +62,7 @@ impl Counter {
 test_that("Macro generation fails on invalid rust code", {
   expect_rextendr_error(
     make_module_macro("#[extendr]\nlet invalid_var = ();"),
-    "Rust code contains invalid attribute macros.
- x No valid `fn` or `impl` block found in the following sample:
- `#\\[extendr\\]
-  let invalid_var = \\(\\);`"
+    "Rust code contains invalid attribute macros."
   )
 })
 

--- a/tests/testthat/test-make-module-macro.R
+++ b/tests/testthat/test-make-module-macro.R
@@ -60,7 +60,7 @@ impl Counter {
 })
 
 test_that("Macro generation fails on invalid rust code", {
-  expect_error(
+  expect_rextendr_error(
     make_module_macro("#[extendr]\nlet invalid_var = ();"),
     "Rust code contains invalid attribute macros.
  x No valid `fn` or `impl` block found in the following sample:
@@ -70,7 +70,7 @@ test_that("Macro generation fails on invalid rust code", {
 })
 
 test_that("Macro generation fails on invalid comments in code", {
-  expect_error(
+  expect_rextendr_error(
     make_module_macro("/*/*/**/"),
     "Malformed comments.
  x Number of start `/\\*` and end `\\*/` delimiters are not equal.
@@ -78,7 +78,7 @@ test_that("Macro generation fails on invalid comments in code", {
  i Found `1` occurence\\(s\\) of `\\*/`."
   )
 
-  expect_error(
+  expect_rextendr_error(
     make_module_macro("*/  /*"),
     "Malformed comments.
  x `/\\*` and `\\*/` are not paired correctly.

--- a/tests/testthat/test-make-module-macro.R
+++ b/tests/testthat/test-make-module-macro.R
@@ -72,17 +72,24 @@ test_that("Macro generation fails on invalid rust code", {
 test_that("Macro generation fails on invalid comments in code", {
   expect_rextendr_error(
     make_module_macro("/*/*/**/"),
-    "Malformed comments.
- x Number of start `/\\*` and end `\\*/` delimiters are not equal.
- i Found `3` occurence\\(s\\) of `/\\*`.
- i Found `1` occurence\\(s\\) of `\\*/`."
+    "Malformed comments."
+  )
+  expect_rextendr_error(
+    make_module_macro("/*/*/**/"),
+    "delimiters are not equal"
+  )
+  expect_rextendr_error(
+    make_module_macro("/*/*/**/"),
+    "Found 3 occurences"
+  )
+  expect_rextendr_error(
+    make_module_macro("/*/*/**/"),
+    "Found 1 occurence"
   )
 
   expect_rextendr_error(
     make_module_macro("*/  /*"),
-    "Malformed comments.
- x `/\\*` and `\\*/` are not paired correctly.
- i This error may be caused by a code fragment like `\\*/ ... /\\*`.",
+    "This error may be caused by a code fragment like",
   )
 })
 

--- a/tests/testthat/test-source.R
+++ b/tests/testthat/test-source.R
@@ -46,7 +46,7 @@ test_that("`options` override `toolchain` value in `rust_source`", {
   options(rextendr.toolchain = "Non-existent-toolchain")
   on.exit(options(old_val))
 
-  expect_error(rust_function("fn rust_test() {}"), "Rust code could not be compiled successfully. Aborting.")
+  expect_rextendr_error(rust_function("fn rust_test() {}"), "Rust code could not be compiled successfully. Aborting.")
 })
 
 test_that("`options` override `patch.crates_io` value in `rust_source`", {
@@ -54,7 +54,7 @@ test_that("`options` override `patch.crates_io` value in `rust_source`", {
   options(rextendr.patch.crates_io = list(`extendr-api` = "-1"))
   on.exit(options(old_val))
 
-  expect_error(rust_function("fn rust_test() {}"), "Rust code could not be compiled successfully. Aborting.")
+  expect_rextendr_error(rust_function("fn rust_test() {}"), "Rust code could not be compiled successfully. Aborting.")
 })
 
 
@@ -63,5 +63,5 @@ test_that("`options` override `rextendr.extendr_deps` value in `rust_source`", {
   options(rextendr.extendr_deps = list(`extendr-api` = "-1"))
   on.exit(options(old_val))
 
-  expect_error(rust_function("fn rust_test() {}"), "Rust code could not be compiled successfully. Aborting.")
+  expect_rextendr_error(rust_function("fn rust_test() {}"), "Rust code could not be compiled successfully. Aborting.")
 })


### PR DESCRIPTION
This is the first of two PRs that I plan to submit to address #62. Doesn't quite close that issue.

This PR:
* Updates all user communication to use `ui_*()` functions
* Refactors `ui_*()` functions to pipe through `rlang::inform()` and to use the new internal function `bullet()` to format text via cli.
* Refactors `ui_throw()` to simplify its logic and use `rlang::abort()` to throw an error of class `rextendr_error`
* Renames and modifies `ui_q()` to `ui_o()` to be more similar to `usethis::ui_todo()`, which is usually how questions are asked in usethis
* Allows global UI silencing via `usethis.quiet = FALSE`. I did this to be consistent with usethis, although you may prefer a custom option like `rextendr.quiet`.
* Updates tests. Generally, these are simplified versions of previous message tests since unicode is a nightmare to handle in regex. I think they are good enough tests for their purposes. I also introduced `expect_rextendr_error()` to more strictly expect an error thrown by rextendr.
* I also ran `use_tidy_description()` 🧹 😄 

Shoutout to @Ilia-Kosenkov who laid the groundwork for this PR!