### PR TITLE
Refactor pkg name calls

### DIFF
--- a/R/register_extendr.R
+++ b/R/register_extendr.R
@@ -25,8 +25,7 @@
 #' @return (Invisibly) Path to the file containing generated wrappers.
 #' @export
 register_extendr <- function(path = ".", quiet = FALSE, force = FALSE, compile = NA) {
-  x <- desc::desc(rprojroot::find_package_root_file("DESCRIPTION", path = path))
-  pkg_name <- x$get("Package")
+  pkg_name <- pkg_name()
 
   if (!isTRUE(quiet)) {
     cli::cli_alert_info("Generating extendr wrapper functions for package: {.pkg {pkg_name}}.")

--- a/R/register_extendr.R
+++ b/R/register_extendr.R
@@ -25,7 +25,7 @@
 #' @return (Invisibly) Path to the file containing generated wrappers.
 #' @export
 register_extendr <- function(path = ".", quiet = FALSE, force = FALSE, compile = NA) {
-  pkg_name <- pkg_name()
+  pkg_name <- pkg_name(path)
 
   if (!isTRUE(quiet)) {
     cli::cli_alert_info("Generating extendr wrapper functions for package: {.pkg {pkg_name}}.")

--- a/R/track_rust_source.R
+++ b/R/track_rust_source.R
@@ -81,11 +81,9 @@ pretty_rel_path <- function(path, search_from = ".") {
 
 get_library_path <- function(path = ".") {
   # Constructs path to the library file (e.g., package_name.dll)
-  pkg <- desc::desc(rprojroot::find_package_root_file("DESCRIPTION", path = path))
-  pkg_name <- pkg$get("Package")
   file.path(
     rprojroot::find_package_root_file("src", path = path),
-    glue::glue("{pkg_name}{.Platform$dynlib.ext}")
+    glue::glue("{pkg_name()}{.Platform$dynlib.ext}")
   )
 }
 

--- a/R/track_rust_source.R
+++ b/R/track_rust_source.R
@@ -83,7 +83,7 @@ get_library_path <- function(path = ".") {
   # Constructs path to the library file (e.g., package_name.dll)
   file.path(
     rprojroot::find_package_root_file("src", path = path),
-    glue::glue("{pkg_name()}{.Platform$dynlib.ext}")
+    glue::glue("{pkg_name(path)}{.Platform$dynlib.ext}")
   )
 }
 

--- a/R/use_extendr.R
+++ b/R/use_extendr.R
@@ -16,8 +16,7 @@
 #' generated or not.
 #' @export
 use_extendr <- function(path = ".", quiet = FALSE) {
-  x <- desc::desc(rprojroot::find_package_root_file("DESCRIPTION", path = path))
-  pkg_name <- x$get("Package")
+  pkg_name <- pkg_name()
 
   src_dir <- rprojroot::find_package_root_file("src", path = path)
   wrappers_file <- rprojroot::find_package_root_file("R", "extendr-wrappers.R", path = path)
@@ -232,4 +231,9 @@ make_example_wrappers <- function(pkg_name, outfile, path = ".", extra_items = N
     rel_path <- pretty_rel_path(outfile, search_from = path)
     cli::cli_alert_success("Writing wrappers to {.file {rel_path}}.")
   }
+}
+
+pkg_name <- function(path =  ".") {
+  x <- desc::desc(rprojroot::find_package_root_file("DESCRIPTION", path = path))
+  x$get("Package")
 }

--- a/R/use_extendr.R
+++ b/R/use_extendr.R
@@ -16,7 +16,7 @@
 #' generated or not.
 #' @export
 use_extendr <- function(path = ".", quiet = FALSE) {
-  pkg_name <- pkg_name()
+  pkg_name <- pkg_name(path)
 
   src_dir <- rprojroot::find_package_root_file("src", path = path)
   wrappers_file <- rprojroot::find_package_root_file("R", "extendr-wrappers.R", path = path)


### PR DESCRIPTION
This little PR refactors a bit of internal code that calls desc in several places in an identical manner to instead use a helper function `pkg_name()`