### PR TITLE
Update tests, bump to testthat 3

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -53,7 +53,7 @@ Suggests:
     knitr,
     rmarkdown,
     rstudioapi,
-    testthat
+    testthat (>= 3.0.0)
 VignetteBuilder: 
     knitr
 Encoding: UTF-8
@@ -62,3 +62,5 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.1
 SystemRequirements: Rust 'cargo'; the crate 'libR-sys' must compile
     without error
+Config/testthat/edition: 3
+Config/testthat/parallel: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -53,14 +53,16 @@ Suggests:
     knitr,
     rmarkdown,
     rstudioapi,
-    testthat (>= 3.0.0)
+    testthat (>= 3.0.0),
+    usethis,
+    withr
 VignetteBuilder: 
     knitr
+Config/testthat/edition: 3
+Config/testthat/parallel: true
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.1
 SystemRequirements: Rust 'cargo'; the crate 'libR-sys' must compile
     without error
-Config/testthat/edition: 3
-Config/testthat/parallel: true

--- a/R/use_extendr.R
+++ b/R/use_extendr.R
@@ -188,8 +188,8 @@ extendr_module! {{
 
   if (!isTRUE(quiet)) {
     ui_v("Finished configuring {.pkg extendr} for package {.pkg {pkg_name}}.")
-    ui_w("Please update the system requirement in {.file DESCRIPTION} file.")
-    ui_w("Please run {.fun rextendr::document} for changes to take effect.")
+    ui_o("Please update the system requirement in {.file DESCRIPTION} file.")
+    ui_o("Please run {.fun rextendr::document} for changes to take effect.")
   }
 
   return(invisible(TRUE))

--- a/tests/testthat/_snaps/use_extendr.md
+++ b/tests/testthat/_snaps/use_extendr.md
@@ -1,0 +1,17 @@
+# use_extendr() sets up extendr files correctly
+
+    Code
+      use_extendr()
+    Message <message>
+      v Creating src/rust/src.
+      v Writing file src/entrypoint.c.
+      v Writing file src/Makevars.
+      v Writing file src/Makevars.win.
+      v Writing file src/.gitignore.
+      v Writing file src/rust/Cargo.toml.
+      v Writing file src/rust/src/lib.rs.
+      v Writing wrappers to R/extendr-wrappers.R.
+      v Finished configuring extendr for package testpkg.
+      * Please update the system requirement in DESCRIPTION file.
+      * Please run `rextendr::document()` for changes to take effect.
+

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -1,3 +1,36 @@
 expect_rextendr_error <- function(...) {
   expect_error(..., class = "rextendr_error")
 }
+
+local_temp_dir <- function(envir = parent.frame()) {
+  current_wd <- getwd()
+  path <- tempfile()
+  dir.create(path)
+
+  setwd(path)
+
+  withr::defer(
+    {
+      setwd(current_wd)
+      usethis::proj_set(NULL)
+      unlink(path)
+    },
+    envir = envir
+  )
+
+  invisible(path)
+}
+
+local_proj_set <- function(envir = parent.frame()) {
+  old_proj <- usethis::proj_set(getwd(), force = TRUE)
+  withr::defer(usethis::proj_set(old_proj), envir = envir)
+}
+
+local_package <- function(nm, envir = parent.frame()) {
+  local_temp_dir(envir = envir)
+  dir <- usethis::create_package(nm)
+  setwd(dir)
+  local_proj_set(envir = envir)
+
+  invisible(dir)
+}

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -14,7 +14,7 @@ expect_rextendr_error <- function(...) {
 #' It also sets the local working directory and usethis project to the temporary
 #' package. These settings are reverted and the package removed via
 #' `withr::defer()`. This clean-up happens at the end of the local scope,
-#' usually the end of a `testthat()` call.
+#' usually the end of a `test_that()` call.
 #'
 #' @param nm The name of the temporary package
 #' @param envir An environment where `withr::defer()`'s exit handler is
@@ -34,7 +34,7 @@ local_package <- function(nm, envir = parent.frame()) {
 #'
 #' `local_temp_dir()` creates a local temporary directory and sets the created
 #' directory as the working directory. These are then cleaned up with
-#' `withr::defer()` at the end of the scope, usually the end of the `testthat()`
+#' `withr::defer()` at the end of the scope, usually the end of the `test_that()`
 #' scope.
 #'
 #' @param envir An environment where `withr::defer()`'s exit handler is
@@ -64,7 +64,7 @@ local_temp_dir <- function(envir = parent.frame()) {
 #'
 #' `local_proj_set()` locally sets a new usethis project. The project is
 #' reverted with `withr::defer()` at the end of the scope, usually the end of
-#' the `testthat()` scope.
+#' the `test_that()` scope.
 #'
 #' @param envir An environment where `withr::defer()`'s exit handler is
 #'   attached, usually the `parent.frame()` to exist locally

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -1,7 +1,46 @@
+#' Does code throw an rextendr_error?
+#'
+#' `expect_rextendr_error()` expects an error of class `rextendr_error`, as
+#' thrown by `ui_throw()`.
+#'
+#' @param ... arguments passed to [testthat::expect_error()]
 expect_rextendr_error <- function(...) {
   expect_error(..., class = "rextendr_error")
 }
 
+#' Create a local package
+#'
+#' `local_package()` creates a self-cleaning test package via usethis and withr.
+#' It also sets the local working directory and usethis project to the temporary
+#' package. These settings are reverted and the package removed via
+#' `withr::defer()`. This clean-up happens at the end of the local scope,
+#' usually the end of a `testthat()` call.
+#'
+#' @param nm The name of the temporary package
+#' @param envir An environment where `withr::defer()`'s exit handler is
+#'   attached, usually the `parent.frame()` to exist locally
+#'
+#' @return A path to the root package directory
+local_package <- function(nm, envir = parent.frame()) {
+  local_temp_dir(envir = envir)
+  dir <- usethis::create_package(nm)
+  setwd(dir)
+  local_proj_set(envir = envir)
+
+  invisible(dir)
+}
+
+#' Create a local temporary directory
+#'
+#' `local_temp_dir()` creates a local temporary directory and sets the created
+#' directory as the working directory. These are then cleaned up with
+#' `withr::defer()` at the end of the scope, usually the end of the `testthat()`
+#' scope.
+#'
+#' @param envir An environment where `withr::defer()`'s exit handler is
+#'   attached, usually the `parent.frame()` to exist locally
+#'
+#' @return A path to the temporary directory
 local_temp_dir <- function(envir = parent.frame()) {
   current_wd <- getwd()
   path <- tempfile()
@@ -21,16 +60,16 @@ local_temp_dir <- function(envir = parent.frame()) {
   invisible(path)
 }
 
+#' Set a local usethis project
+#'
+#' `local_proj_set()` locally sets a new usethis project. The project is
+#' reverted with `withr::defer()` at the end of the scope, usually the end of
+#' the `testthat()` scope.
+#'
+#' @param envir An environment where `withr::defer()`'s exit handler is
+#'   attached, usually the `parent.frame()` to exist locally
 local_proj_set <- function(envir = parent.frame()) {
   old_proj <- usethis::proj_set(getwd(), force = TRUE)
   withr::defer(usethis::proj_set(old_proj), envir = envir)
 }
 
-local_package <- function(nm, envir = parent.frame()) {
-  local_temp_dir(envir = envir)
-  dir <- usethis::create_package(nm)
-  setwd(dir)
-  local_proj_set(envir = envir)
-
-  invisible(dir)
-}

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,0 +1,3 @@
+old_test_settings <- options(
+  usethis.quiet = TRUE
+)

--- a/tests/testthat/teardown.R
+++ b/tests/testthat/teardown.R
@@ -1,0 +1,1 @@
+options(old_test_settings)

--- a/tests/testthat/test-helper-functions.R
+++ b/tests/testthat/test-helper-functions.R
@@ -15,7 +15,7 @@ test_that("`pretty_rel_path()` works", {
     devtools::create(pkg_root),
     finally = sink()
   )
-  rextendr::use_extendr(pkg_root, quiet = TRUE)
+  rextendr::use_extendr(pkg_root)
 
   # Find relative path from package root, trivial case
   expect_equal(
@@ -296,6 +296,7 @@ test_that("`write_file()` does the same as `brio::write_lines()`", {
   # Writing using {brio} and {rextendr}
   brio::write_lines(text, temp_file_brio)
   # `write_file()` produces a {cli} message
+  withr::local_options(usethis.quiet = FALSE)
   expect_message(write_file(text, temp_file_rxr), "Writing file")
 
   # Verifies file content

--- a/tests/testthat/test-helper-functions.R
+++ b/tests/testthat/test-helper-functions.R
@@ -281,17 +281,8 @@ test_that("`write_file()` does the same as `brio::write_lines()`", {
   )
 
   # Creating two temp files for {rextendr} and {brio}.
-  temp_file_rxr <- tempfile(pattern = "rxr_")
-  temp_file_brio <- tempfile(pattern = "brio_")
-
-  # Explicitly removing temporary files
-  on.exit(
-    {
-      unlink(temp_file_rxr)
-      unlink(temp_file_brio)
-    },
-    add = TRUE
-  )
+  temp_file_rxr <- withr::local_tempfile(pattern = "rxr_")
+  temp_file_brio <- withr::local_tempfile(pattern = "brio_")
 
   # Writing using {brio} and {rextendr}
   brio::write_lines(text, temp_file_brio)

--- a/tests/testthat/test-helper-functions.R
+++ b/tests/testthat/test-helper-functions.R
@@ -15,7 +15,7 @@ test_that("`pretty_rel_path()` works", {
     devtools::create(pkg_root),
     finally = sink()
   )
-  rextendr::use_extendr(pkg_root)
+  use_extendr(pkg_root)
 
   # Find relative path from package root, trivial case
   expect_equal(

--- a/tests/testthat/test-helper-functions.R
+++ b/tests/testthat/test-helper-functions.R
@@ -2,7 +2,7 @@
 # Test if `pretty_rel_path` determines relative paths correctly.
 # Edge cases include initiating the search from a directory outside of
 # package directory (an ancestor/parent in the hierarchy), and
-# from a non-exstenst/invalid directory (such as `NA` or `""`),
+# from a non-existent/invalid directory (such as `NA` or `""`),
 # in which case `pretty_rel_path` should return absolute path of itr
 # first argument.
 test_that("`pretty_rel_path()` works", {

--- a/tests/testthat/test-helper-functions.R
+++ b/tests/testthat/test-helper-functions.R
@@ -6,16 +6,8 @@
 # in which case `pretty_rel_path` should return absolute path of itr
 # first argument.
 test_that("`pretty_rel_path()` works", {
-  tempdir <- tempdir()
-  pkg_root <- file.path(tempdir, "testpkg")
-  dir.create(pkg_root, recursive = TRUE)
-  pkg_root <- normalizePath(pkg_root, winslash = "/")
-  sink(nullfile())
-  tryCatch(
-    devtools::create(pkg_root),
-    finally = sink()
-  )
-  use_extendr(pkg_root)
+  pkg_root <- local_package("testpkg")
+  use_extendr()
 
   # Find relative path from package root, trivial case
   expect_equal(

--- a/tests/testthat/test-source.R
+++ b/tests/testthat/test-source.R
@@ -42,26 +42,17 @@ test_that("`rust_source()` works", {
 
 
 test_that("`options` override `toolchain` value in `rust_source`", {
-  old_val <- options("rextendr.toolchain")
-  options(rextendr.toolchain = "Non-existent-toolchain")
-  on.exit(options(old_val))
-
+  withr::local_options(rextendr.toolchain = "Non-existent-toolchain")
   expect_rextendr_error(rust_function("fn rust_test() {}"), "Rust code could not be compiled successfully. Aborting.")
 })
 
 test_that("`options` override `patch.crates_io` value in `rust_source`", {
-  old_val <- options("rextendr.patch.crates_io")
-  options(rextendr.patch.crates_io = list(`extendr-api` = "-1"))
-  on.exit(options(old_val))
-
+  withr::local_options(rextendr.patch.crates_io = list(`extendr-api` = "-1"))
   expect_rextendr_error(rust_function("fn rust_test() {}"), "Rust code could not be compiled successfully. Aborting.")
 })
 
 
 test_that("`options` override `rextendr.extendr_deps` value in `rust_source`", {
-  old_val <- options("rextendr.extendr_deps")
-  options(rextendr.extendr_deps = list(`extendr-api` = "-1"))
-  on.exit(options(old_val))
-
+  withr::local_options(rextendr.extendr_deps = list(`extendr-api` = "-1"))
   expect_rextendr_error(rust_function("fn rust_test() {}"), "Rust code could not be compiled successfully. Aborting.")
 })

--- a/tests/testthat/test-use_extendr.R
+++ b/tests/testthat/test-use_extendr.R
@@ -1,0 +1,44 @@
+test_that("use_extendr() sets up extendr files correctly", {
+  path <- local_package("testpkg")
+  # capture setup messages
+  withr::local_options(usethis.quiet = FALSE)
+  expect_snapshot(use_extendr())
+
+  # directory structure
+  expect_true(dir.exists("src"))
+  expect_true(dir.exists(file.path("src", "rust")))
+  expect_true(dir.exists(file.path("src", "rust", "src")))
+
+  # extendr files
+  expect_true(file.exists(file.path("R", "extendr-wrappers.R")))
+  expect_true(file.exists(file.path("src", "Makevars")))
+  expect_true(file.exists(file.path("src", "Makevars.win")))
+  expect_true(file.exists(file.path("src", "entrypoint.c")))
+  expect_true(file.exists(file.path("src", "rust", "Cargo.toml")))
+  expect_true(file.exists(file.path("src", "rust", "src", "lib.rs")))
+})
+
+test_that("use_extendr() does not set up packages with pre-existing src", {
+  path <- local_package("testpkg.src")
+  dir.create("src")
+  withr::local_options(usethis.quiet = FALSE)
+  expect_message(
+    created <- use_extendr(),
+    "already present in package source. No action taken."
+  )
+
+  expect_false(created)
+})
+
+
+test_that("use_extendr() does not set up packages with pre-existing wrappers", {
+  path <- local_package("testpkg.wrap")
+  usethis::use_r("extendr-wrappers", open = FALSE)
+  withr::local_options(usethis.quiet = FALSE)
+  expect_message(
+    created <- use_extendr(),
+    "already present in package source. No action taken."
+  )
+
+  expect_false(created)
+})


### PR DESCRIPTION
This PR refactors the tests in several ways:

1. Bump the testthat version to edition 3 and use parallel tests. This turned out to be easy, as none of the tests failed after 😎 
2. Use `usethis.quiet` introduced in #94 to quiet all tests prior to running (I bumped into noisy tests running them in certain ways) and reset options during teardown
3. Adds withr and usethis to Suggests, which were already implicitly suggested via devtools. 
4. Uses withr to manage local states, e.g. temp files or options
5. Uses withr and usethis to create local packages via `local_package()`. This is a [self-cleaning test fixture](https://www.tidyverse.org/blog/2020/04/self-cleaning-test-fixtures/).
6. Adds direct tests for `use_extendr()`

I thought about more generally improving test coverage, but this seems reasonable for now and will let me finish #62 a bit more easily

Closes #98 