### PR TITLE
Style code and add PR commands for styling and documenting

### DIFF
--- a/.github/workflows/pr-commands.yaml
+++ b/.github/workflows/pr-commands.yaml
@@ -1,0 +1,55 @@
+on:
+  issue_comment:
+    types: [created]
+name: Commands
+jobs:
+  document:
+    if: startsWith(github.event.comment.body, '/document')
+    name: document
+    runs-on: macOS-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: r-lib/actions/pr-fetch@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: r-lib/actions/setup-r@v1
+      - name: Install dependencies
+        run: Rscript -e 'install.packages(c("remotes", "roxygen2"))' -e 'remotes::install_deps(dependencies = TRUE)'
+      - name: Document
+        run: Rscript -e 'roxygen2::roxygenise()'
+      - name: commit
+        run: |
+          git config --local user.email "actions@github.com"
+          git config --local user.name "GitHub Actions"
+          git add man/\* NAMESPACE
+          git commit -m 'Document'
+      - uses: r-lib/actions/pr-push@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+  style:
+    if: startsWith(github.event.comment.body, '/style')
+    name: style
+    runs-on: macOS-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: r-lib/actions/pr-fetch@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: r-lib/actions/setup-r@v1
+      - name: Install dependencies
+        run: Rscript -e 'install.packages("styler")'
+      - name: Style
+        run: Rscript -e 'styler::style_pkg()'
+      - name: commit
+        run: |
+          git config --local user.email "actions@github.com"
+          git config --local user.name "GitHub Actions"
+          git add \*.R
+          git commit -m 'Style'
+      - uses: r-lib/actions/pr-push@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/R/clean_code.R
+++ b/R/clean_code.R
@@ -48,7 +48,7 @@ fill_block_comments <- function(lns, fill_with = " ") {
   # Fast path if no comments are found at all.
   if (
     all(is.na(comment_syms[["start"]])) &&
-    all(is.na(comment_syms[["end"]]))
+      all(is.na(comment_syms[["end"]]))
   ) {
     return(
       stringi::stri_split_lines(
@@ -112,7 +112,7 @@ fill_block_comments <- function(lns, fill_with = " ") {
   n_valid <- nrow(to_replace)
   if (
     any(to_replace[["type"]][2L * seq_len(n_valid / 2L) - 1L] != "open") ||
-    any(to_replace[["type"]][2L * seq_len(n_valid / 2L)] != "close")
+      any(to_replace[["type"]][2L * seq_len(n_valid / 2L)] != "close")
   ) {
     ui_throw(
       "Malformed comments.",

--- a/R/eval.R
+++ b/R/eval.R
@@ -19,12 +19,12 @@
 #'
 #' # Rust code with return value
 #' rust_eval(
-#'   code = '
+#'   code = "
 #'     let x = 5;
 #'     let y = 7;
 #'     let z = x * y;
 #'     z // return to R; rust_eval() takes care of type conversion code
-#'  '
+#'  "
 #' )
 #' }
 #' @export

--- a/R/install_libR_bindings.R
+++ b/R/install_libR_bindings.R
@@ -35,13 +35,13 @@ install_libR_bindings <- function(version = "*", force = FALSE, quiet = FALSE, p
   cargo.toml <- c(
     '[package]\nname = "build-libR-sys"\nversion = "0.0.1"\nedition = "2018"',
     glue('[dependencies]\nlibR-sys = "{version}"'),
-    '[patch.crates-io]',
+    "[patch.crates-io]",
     patch.crates_io
   )
   brio::write_lines(cargo.toml, file.path(dir, "Cargo.toml"))
   lib.rs <- c(
-    '#![allow(non_snake_case)]',
-    'pub const DUMMY: u32 = 0;'
+    "#![allow(non_snake_case)]",
+    "pub const DUMMY: u32 = 0;"
   )
   brio::write_lines(lib.rs, file.path(dir, "src", "lib.rs"))
   on.exit(unlink(dir, recursive = TRUE))
@@ -72,7 +72,7 @@ install_libR_bindings <- function(version = "*", force = FALSE, quiet = FALSE, p
     cargo.lock <- brio::read_lines(file.path(dir, "Cargo.lock"))
     idx <- which(grepl("name = \"libR-sys\"", cargo.lock))
     version_line <- cargo.lock[idx + 1]
-    #message("Installed libR-sys version:\n", version_line)
+    # message("Installed libR-sys version:\n", version_line)
 
     # patch Cargo.toml file
     installed_cargo.toml <- file.path(package_dir, "rust", "libR-sys", "Cargo.toml")

--- a/R/knitr_engine.R
+++ b/R/knitr_engine.R
@@ -44,7 +44,7 @@ eng_impl <- function(options, rextendr_fun) {
   if (!is.environment(opts$env)) opts$env <- knitr::knit_global() # default env is knit_global()
 
   if (isTRUE(options$eval)) {
-    ui_v('Evaluating Rust extendr code chunk...')
+    ui_v("Evaluating Rust extendr code chunk...")
     out <- utils::capture.output({
       result <- withVisible(
         do.call(rextendr_fun, c(list(code = code), opts))

--- a/R/use_extendr.R
+++ b/R/use_extendr.R
@@ -234,7 +234,7 @@ make_example_wrappers <- function(pkg_name, outfile, path = ".", extra_items = N
   brio::write_lines(wrappers_content, outfile)
 }
 
-pkg_name <- function(path =  ".") {
+pkg_name <- function(path = ".") {
   x <- desc::desc(rprojroot::find_package_root_file("DESCRIPTION", path = path))
   x$get("Package")
 }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -18,13 +18,13 @@
   rextendr_opts <- list(
     # Controls default Rust toolchain; NULL corresponds to system's default
     rextendr.toolchain = NULL,
-#   rextendr.toolchain = "nightly",    # use 'nightly' tool chain
+    #   rextendr.toolchain = "nightly",    # use 'nightly' tool chain
 
     # Overrides Rust dependencies; mainly used for development
-    rextendr.patch.crates_io = NULL,   # most recent extendr crates on crates.io
-#    rextendr.patch.crates_io = list(  # most recent extendr crates on github
-#      `extendr-api` = git_ref
-#    ),
+    rextendr.patch.crates_io = NULL, # most recent extendr crates on crates.io
+    #    rextendr.patch.crates_io = list(  # most recent extendr crates on github
+    #      `extendr-api` = git_ref
+    #    ),
 
     # Version of 'extendr_api' to be used
     rextendr.extendr_deps = list(

--- a/tests/testthat/test-name-override.R
+++ b/tests/testthat/test-name-override.R
@@ -1,5 +1,4 @@
 test_that("Multiple rust functions with the same name", {
-
   rust_src_1 <- "
   #[extendr]
   fn rust_fn_1() -> i32 { 1i32 }
@@ -18,9 +17,9 @@ test_that("Multiple rust functions with the same name", {
 
   rust_source(
     code = rust_src_1,
-    quiet = FALSE#,
-    #toolchain = rust_source_defaults[["toolchain"]],
-    #patch.crates_io = rust_source_defaults[["patch.crates_io"]]
+    quiet = FALSE # ,
+    # toolchain = rust_source_defaults[["toolchain"]],
+    # patch.crates_io = rust_source_defaults[["patch.crates_io"]]
   )
 
   # At this point:
@@ -33,9 +32,9 @@ test_that("Multiple rust functions with the same name", {
 
   rust_source(
     code = rust_src_2,
-    quiet = FALSE#,
-    #toolchain = rust_source_defaults[["toolchain"]],
-    #patch.crates_io = rust_source_defaults[["patch.crates_io"]]
+    quiet = FALSE # ,
+    # toolchain = rust_source_defaults[["toolchain"]],
+    # patch.crates_io = rust_source_defaults[["patch.crates_io"]]
   )
 
   # At this point:


### PR DESCRIPTION
This PR runs `styler::style_pkg()` and adds [GitHub Actions workflows that create the commands `/style` and `/document`](https://github.com/r-lib/actions/tree/master/examples#commands-workflow), which you can run on incoming PRs 