### PR TITLE
Use templates in `use_extendr()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -56,6 +56,7 @@ Imports:
 Suggests: 
     devtools,
     knitr,
+    mockr,
     rmarkdown,
     rstudioapi,
     testthat (>= 3.0.0),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -52,7 +52,8 @@ Imports:
     rlang (>= 0.4.10),
     rprojroot,
     stringi,
-    tibble
+    tibble,
+    withr
 Suggests: 
     devtools,
     knitr,
@@ -60,8 +61,7 @@ Suggests:
     rmarkdown,
     rstudioapi,
     testthat (>= 3.0.0),
-    usethis,
-    withr
+    usethis
 VignetteBuilder: 
     knitr
 Config/testthat/edition: 3

--- a/R/use_extendr.R
+++ b/R/use_extendr.R
@@ -195,6 +195,45 @@ extendr_module! {{
   return(invisible(TRUE))
 }
 
+use_rextendr_template <- function(template, save_as = template, data = list()) {
+  if (is_installed("usethis")) {
+    created <- usethis::use_template(
+      template,
+      save_as = save_as,
+      data = data,
+      open = FALSE,
+      package = "rextendr"
+    )
+
+    return(invisible(created))
+  }
+
+  template_path <- system.file(
+    "templates",
+    template,
+    package = "rextendr",
+    mustWork = TRUE
+  )
+
+  template_content <- brio::read_file(template_path)
+
+  template_content <- glue::glue_data(
+    template_content,
+    .envir = data,
+    .open = "{{{", .close = "}}}"
+  )
+
+  ui_v("Writing {.file save_as}")
+  brio::write_file(template_content, path = save_as)
+
+  invisible(TRUE)
+}
+
+#' Wrap `rlang::is_installed()` for ease of mocking installed packages
+is_installed <- function(pkg) {
+  rlang::is_installed(pkg)
+}
+
 #' Creates example R wrappers for Rust functions.
 #'
 #' Writes simple R wrappers, without which initial compilation of the

--- a/R/use_extendr.R
+++ b/R/use_extendr.R
@@ -34,7 +34,7 @@ use_extendr <- function(path = ".", quiet = getOption("usethis.quiet", FALSE)) {
     return(invisible(FALSE))
   }
 
-  rust_src_dir <- file.path("src", "rust", "src")
+  rust_src_dir <- file.path(src_dir, "rust", "src")
   dir.create(rust_src_dir, recursive = TRUE)
   ui_v("Creating {.file {pretty_rel_path(rust_src_dir, path)}}.")
 

--- a/R/use_extendr.R
+++ b/R/use_extendr.R
@@ -15,7 +15,6 @@
 #' @return A logical value (invisible) indicating whether any package files were
 #' generated or not.
 #' @export
-
 use_extendr <- function(path = ".", quiet = getOption("usethis.quiet", FALSE)) {
   pkg_name <- pkg_name(path)
 
@@ -35,98 +34,34 @@ use_extendr <- function(path = ".", quiet = getOption("usethis.quiet", FALSE)) {
     return(invisible(FALSE))
   }
 
-  rust_src_dir <- file.path(src_dir, "rust", "src")
+  rust_src_dir <- file.path("src", "rust", "src")
   dir.create(rust_src_dir, recursive = TRUE)
   ui_v("Creating {.file {pretty_rel_path(rust_src_dir, path)}}.")
 
-  entrypoint_content <- glue(
-    r"(
-// We need to forward routine registration from C to Rust
-// to avoid the linker removing the static library.
-
-void R_init_{pkg_name}_extendr(void *dll);
-
-void R_init_{pkg_name}(void *dll) {{
-    R_init_{pkg_name}_extendr(dll);
-}}
-)"
+  use_rextendr_template(
+    "entrypoint.c",
+    save_as = file.path("src", "entrypoint.c"),
+    quiet = quiet,
+    data = list(pkg_name = pkg_name)
   )
 
-  write_file(
-    text = entrypoint_content,
-    path = file.path(src_dir, "entrypoint.c"),
-    search_root_from = path,
-    quiet = quiet
+  use_rextendr_template(
+    "Makevars",
+    save_as = file.path("src", "Makevars"),
+    quiet = quiet,
+    data = list(pkg_name = pkg_name)
   )
 
-  makevars_content <- glue(
-    "
-LIBDIR = ./rust/target/release
-STATLIB = $(LIBDIR)/lib{pkg_name}.a
-PKG_LIBS = -L$(LIBDIR) -l{pkg_name}
-
-all: C_clean
-
-$(SHLIB): $(STATLIB)
-
-$(STATLIB):
-\tcargo build --lib --release --manifest-path=./rust/Cargo.toml
-
-C_clean:
-\trm -Rf $(SHLIB) $(STATLIB) $(OBJECTS)
-
-clean:
-\trm -Rf $(SHLIB) $(STATLIB) $(OBJECTS) rust/target
-"
+  use_rextendr_template(
+    "Makevars.win",
+    save_as = file.path("src", "Makevars.win"),
+    quiet = quiet,
+    data = list(pkg_name = pkg_name)
   )
 
-  write_file(
-    text = makevars_content,
-    path = file.path(src_dir, "Makevars"),
-    search_root_from = path,
-    quiet = quiet
-  )
-
-  makevars_win_content <- glue(
-    "
-TARGET = $(subst 64,x86_64,$(subst 32,i686,$(WIN)))-pc-windows-gnu
-LIBDIR = ./rust/target/$(TARGET)/release
-STATLIB = $(LIBDIR)/lib{pkg_name}.a
-PKG_LIBS = -L$(LIBDIR) -l{pkg_name} -lws2_32 -ladvapi32 -luserenv
-
-all: C_clean
-
-$(SHLIB): $(STATLIB)
-
-$(STATLIB):
-\tcargo build --target=$(TARGET) --lib --release --manifest-path=./rust/Cargo.toml
-
-C_clean:
-\trm -Rf $(SHLIB) $(STATLIB) $(OBJECTS)
-
-clean:
-\trm -Rf $(SHLIB) $(STATLIB) $(OBJECTS) rust/target
-"
-  )
-
-  write_file(
-    text = makevars_win_content,
-    path = file.path(src_dir, "Makevars.win"),
-    search_root_from = path,
-    quiet = quiet
-  )
-
-
-  gitignore_content <- "*.o
-*.so
-*.dll
-target
-"
-
-  write_file(
-    text = gitignore_content,
-    path = file.path(src_dir, ".gitignore"),
-    search_root_from = path,
+  use_rextendr_template(
+    "_gitignore",
+    save_as = file.path("src", ".gitignore"),
     quiet = quiet
   )
 
@@ -138,53 +73,24 @@ target
 
   write_file(
     text = cargo_toml_content,
-    path = file.path(src_dir, "rust", "Cargo.toml"),
+    path = file.path("src", "rust", "Cargo.toml"),
     search_root_from = path,
     quiet = quiet
   )
 
-
-  lib_rs_content <- glue(
-    r"(
-use extendr_api::prelude::*;
-
-/// Return string `"Hello world!"` to R.
-/// @export
-#[extendr]
-fn hello_world() -> &'static str {{
-    "Hello world!"
-}}
-
-// Macro to generate exports.
-// This ensures exported functions are registered with R.
-// See corresponding C code in `entrypoint.c`.
-extendr_module! {{
-    mod {pkg_name};
-    fn hello_world;
-}}
-)"
+  use_rextendr_template(
+    "lib.rs",
+    save_as = file.path("src", "rust", "src", "lib.rs"),
+    quiet = quiet,
+    data = list(pkg_name = pkg_name)
   )
 
-
-  write_file(
-    text = lib_rs_content,
-    path = file.path(rust_src_dir, "lib.rs"),
-    search_root_from = path,
-    quiet = quiet
+  use_rextendr_template(
+    "extendr-wrappers.R",
+    save_as = file.path("R", "extendr-wrappers.R"),
+    quiet = quiet,
+    data = list(pkg_name = pkg_name)
   )
-
-
-  roxcmt <- "#'" # workaround for roxygen parsing bug in raw strings
-
-  example_function_wrapper <- glue(
-    r"(
-    {roxcmt} Return string `"Hello world!"` to R.
-    {roxcmt} @export
-    hello_world <- function() .Call(wrap__hello_world)
-    )"
-  )
-
-  make_example_wrappers(pkg_name, wrappers_file, extra_items = example_function_wrapper, path = path)
 
   if (!isTRUE(quiet)) {
     ui_v("Finished configuring {.pkg extendr} for package {.pkg {pkg_name}}.")
@@ -195,7 +101,16 @@ extendr_module! {{
   return(invisible(TRUE))
 }
 
-use_rextendr_template <- function(template, save_as = template, data = list()) {
+#' Write templates from `inst/templates`
+#'
+#' `use_rextendr_template()` is a wrapper around `usethis::use_template()` when
+#' it's available and otherwise implements a simple version of `use_template()`.
+#'
+#' @inheritParams usethis::use_template
+#' @inheritParams use_extendr
+#'
+#' @noRd
+use_rextendr_template <- function(template, save_as = template, data = list(), quiet = getOption("usethis.quiet", FALSE)) {
   if (is_installed("usethis")) {
     created <- usethis::use_template(
       template,
@@ -219,57 +134,23 @@ use_rextendr_template <- function(template, save_as = template, data = list()) {
 
   template_content <- glue::glue_data(
     template_content,
-    .envir = data,
+    .x = data,
     .open = "{{{", .close = "}}}"
   )
 
-  write_file(template_content, path = save_as, search_root_from = path)
+  write_file(
+    template_content,
+    path = save_as,
+    search_root_from = rprojroot::find_package_root_file(),
+    quiet = quiet
+  )
 
   invisible(TRUE)
 }
 
-#' Wrap `rlang::is_installed()` for ease of mocking installed packages
+# Wrap `rlang::is_installed()` for ease of mocking installed packages
 is_installed <- function(pkg) {
   rlang::is_installed(pkg)
-}
-
-#' Creates example R wrappers for Rust functions.
-#'
-#' Writes simple R wrappers, without which initial compilation of the
-#' package is impossible. Does not require a compiled library.
-#' Can be used as a fallback.
-#' @param pkg_name The name of the package.
-#' @param outfile Determines where to write wrapper code.
-#' @param path Path from which package root is looked up. Used for pretty message formatting.
-#' @param extra_items Character vector or `NULL` containing additional wrappers.
-#' Should be valid R code.
-#' @param quiet Logical scalar indicating whether the output should be quiet (`TRUE`)
-#'   or verbose (`FALSE`).
-#' @noRd
-make_example_wrappers <- function(pkg_name, outfile, path = ".", extra_items = NULL, quiet = FALSE) {
-  roxcmt <- "#'" # workaround for roxygen parsing bug in raw strings
-
-  wrappers_content <- glue::glue(
-    r"(
-    {roxcmt} @docType package
-    {roxcmt} @usage NULL
-    {roxcmt} @useDynLib {pkg_name}, .registration = TRUE
-    NULL
-    )"
-  )
-
-  if (!is.null(extra_items)) {
-    wrappers_content <- glue::glue_collapse(
-      c(wrappers_content, extra_items),
-      sep = "\n"
-    )
-  }
-
-  if (!isTRUE(quiet)) {
-    rel_path <- pretty_rel_path(outfile, search_from = path)
-    ui_v("Writing wrappers to {.file {rel_path}}.")
-  }
-  brio::write_lines(wrappers_content, outfile)
 }
 
 pkg_name <- function(path = ".") {

--- a/R/use_extendr.R
+++ b/R/use_extendr.R
@@ -223,8 +223,7 @@ use_rextendr_template <- function(template, save_as = template, data = list()) {
     .open = "{{{", .close = "}}}"
   )
 
-  ui_v("Writing {.file save_as}")
-  brio::write_file(template_content, path = save_as)
+  write_file(template_content, path = save_as, search_root_from = path)
 
   invisible(TRUE)
 }

--- a/R/use_extendr.R
+++ b/R/use_extendr.R
@@ -112,6 +112,7 @@ use_extendr <- function(path = ".", quiet = getOption("usethis.quiet", FALSE)) {
 #' @noRd
 use_rextendr_template <- function(template, save_as = template, data = list(), quiet = getOption("usethis.quiet", FALSE)) {
   if (is_installed("usethis")) {
+    withr::local_options(usethis.quiet = quiet)
     created <- usethis::use_template(
       template,
       save_as = save_as,

--- a/R/write_file.R
+++ b/R/write_file.R
@@ -15,6 +15,7 @@
 #' @noRd
 write_file <- function(text, path, search_root_from = ".", quiet = getOption("usethis.quiet", FALSE)) {
   line_ending <- if (.Platform$OS.type == "windows") "\r\n" else "\n"
+  text <- gsub("\r?\n", line_ending, text)
   output <- brio::write_lines(text = text, path = path, eol = line_ending)
   if (!isTRUE(quiet)) {
     rel_path <- pretty_rel_path(path, search_from = search_root_from)

--- a/R/write_file.R
+++ b/R/write_file.R
@@ -14,7 +14,8 @@
 #' @return The output of [`brio::write_lines()`] (invisibly).
 #' @noRd
 write_file <- function(text, path, search_root_from = ".", quiet = getOption("usethis.quiet", FALSE)) {
-  output <- brio::write_lines(text = text, path = path)
+  line_ending <- if (.Platform$OS.type == "windows") "\r\n" else "\n"
+  output <- brio::write_lines(text = text, path = path, eol = line_ending)
   if (!isTRUE(quiet)) {
     rel_path <- pretty_rel_path(path, search_from = search_root_from)
     ui_v("Writing {.file {rel_path}}.")

--- a/R/write_file.R
+++ b/R/write_file.R
@@ -17,7 +17,7 @@ write_file <- function(text, path, search_root_from = ".", quiet = getOption("us
   output <- brio::write_lines(text = text, path = path)
   if (!isTRUE(quiet)) {
     rel_path <- pretty_rel_path(path, search_from = search_root_from)
-    ui_v("Writing '{.file {rel_path}}'.")
+    ui_v("Writing {.file {rel_path}}.")
   }
   invisible(output)
 }

--- a/R/write_file.R
+++ b/R/write_file.R
@@ -15,7 +15,6 @@
 #' @noRd
 write_file <- function(text, path, search_root_from = ".", quiet = getOption("usethis.quiet", FALSE)) {
   line_ending <- if (.Platform$OS.type == "windows") "\r\n" else "\n"
-  text <- gsub("\r?\n", line_ending, text)
   output <- brio::write_lines(text = text, path = path, eol = line_ending)
   if (!isTRUE(quiet)) {
     rel_path <- pretty_rel_path(path, search_from = search_root_from)

--- a/R/write_file.R
+++ b/R/write_file.R
@@ -14,8 +14,7 @@
 #' @return The output of [`brio::write_lines()`] (invisibly).
 #' @noRd
 write_file <- function(text, path, search_root_from = ".", quiet = getOption("usethis.quiet", FALSE)) {
-  line_ending <- if (.Platform$OS.type == "windows") "\r\n" else "\n"
-  output <- brio::write_lines(text = text, path = path, eol = line_ending)
+  output <- brio::write_lines(text = text, path = path)
   if (!isTRUE(quiet)) {
     rel_path <- pretty_rel_path(path, search_from = search_root_from)
     ui_v("Writing {.file {rel_path}}.")

--- a/R/write_file.R
+++ b/R/write_file.R
@@ -17,7 +17,7 @@ write_file <- function(text, path, search_root_from = ".", quiet = getOption("us
   output <- brio::write_lines(text = text, path = path)
   if (!isTRUE(quiet)) {
     rel_path <- pretty_rel_path(path, search_from = search_root_from)
-    ui_v("Writing file {.file {rel_path}}.")
+    ui_v("Writing '{.file {rel_path}}'.")
   }
   invisible(output)
 }

--- a/inst/templates/Makevars
+++ b/inst/templates/Makevars
@@ -1,0 +1,16 @@
+LIBDIR = ./rust/target/release
+STATLIB = $(LIBDIR)/lib{{{pkg_name}}}.a
+PKG_LIBS = -L$(LIBDIR) -l{{{pkg_name}}}
+
+all: C_clean
+
+$(SHLIB): $(STATLIB)
+
+$(STATLIB):
+	cargo build --lib --release --manifest-path=./rust/Cargo.toml
+
+C_clean:
+	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS)
+
+clean:
+	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS) rust/target

--- a/inst/templates/Makevars.win
+++ b/inst/templates/Makevars.win
@@ -1,0 +1,17 @@
+TARGET = $(subst 64,x86_64,$(subst 32,i686,$(WIN)))-pc-windows-gnu
+LIBDIR = ./rust/target/$(TARGET)/release
+STATLIB = $(LIBDIR)/lib{{{pkg_name}}}.a
+PKG_LIBS = -L$(LIBDIR) -l{{{pkg_name}}} -lws2_32 -ladvapi32 -luserenv
+
+all: C_clean
+
+$(SHLIB): $(STATLIB)
+
+$(STATLIB):
+	cargo build --target=$(TARGET) --lib --release --manifest-path=./rust/Cargo.toml
+
+C_clean:
+	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS)
+
+clean:
+	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS) rust/target

--- a/inst/templates/_gitignore
+++ b/inst/templates/_gitignore
@@ -1,0 +1,4 @@
+*.o
+*.so
+*.dll
+target

--- a/inst/templates/entrypoint.c
+++ b/inst/templates/entrypoint.c
@@ -1,0 +1,8 @@
+// We need to forward routine registration from C to Rust
+// to avoid the linker removing the static library.
+
+void R_init_{{{pkg_name}}}_extendr(void *dll);
+
+void R_init_{{{pkg_name}}}(void *dll) {
+    R_init_{{{pkg_name}}}_extendr(dll);
+}

--- a/inst/templates/extendr-wrappers.R
+++ b/inst/templates/extendr-wrappers.R
@@ -1,0 +1,8 @@
+#' @docType package
+#' @usage NULL
+#' @useDynLib {{{pkg_name}}}, .registration = TRUE
+NULL
+
+#' Return string `"Hello world!"` to R.
+#' @export
+hello_world <- function() .Call(wrap__hello_world)

--- a/inst/templates/lib.rs
+++ b/inst/templates/lib.rs
@@ -1,0 +1,16 @@
+use extendr_api::prelude::*;
+
+/// Return string `"Hello world!"` to R.
+/// @export
+#[extendr]
+fn hello_world() -> &'static str {
+    "Hello world!"
+}
+
+// Macro to generate exports.
+// This ensures exported functions are registered with R.
+// See corresponding C code in `entrypoint.c`.
+extendr_module! {
+    mod {{{pkg_name}}};
+    fn hello_world;
+}

--- a/tests/testthat/_snaps/use_extendr.md
+++ b/tests/testthat/_snaps/use_extendr.md
@@ -3,7 +3,7 @@
     Code
       use_extendr()
     Message <message>
-      v Creating src/rust/src.
+      v Creating 'src/rust/src'.
       v Writing 'src/entrypoint.c'
       v Writing 'src/Makevars'
       v Writing 'src/Makevars.win'
@@ -12,7 +12,7 @@
       v Writing 'src/rust/src/lib.rs'
       v Writing 'R/extendr-wrappers.R'
       v Finished configuring extendr for package testpkg.
-      * Please update the system requirement in DESCRIPTION file.
+      * Please update the system requirement in 'DESCRIPTION' file.
       * Please run `rextendr::document()` for changes to take effect.
 
 ---

--- a/tests/testthat/_snaps/use_extendr.md
+++ b/tests/testthat/_snaps/use_extendr.md
@@ -15,3 +15,113 @@
       * Please update the system requirement in DESCRIPTION file.
       * Please run `rextendr::document()` for changes to take effect.
 
+---
+
+    Code
+      cat_file("R", "extendr-wrappers.R")
+    Output
+      #' @docType package
+      #' @usage NULL
+      #' @useDynLib testpkg, .registration = TRUE
+      NULL
+      #' Return string `"Hello world!"` to R.
+      #' @export
+      hello_world <- function() .Call(wrap__hello_world)
+
+---
+
+    Code
+      cat_file("src", "Makevars")
+    Output
+      LIBDIR = ./rust/target/release
+      STATLIB = $(LIBDIR)/libtestpkg.a
+      PKG_LIBS = -L$(LIBDIR) -ltestpkg
+      
+      all: C_clean
+      
+      $(SHLIB): $(STATLIB)
+      
+      $(STATLIB):
+      	cargo build --lib --release --manifest-path=./rust/Cargo.toml
+      
+      C_clean:
+      	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS)
+      
+      clean:
+      	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS) rust/target
+
+---
+
+    Code
+      cat_file("src", "Makevars.win")
+    Output
+      TARGET = $(subst 64,x86_64,$(subst 32,i686,$(WIN)))-pc-windows-gnu
+      LIBDIR = ./rust/target/$(TARGET)/release
+      STATLIB = $(LIBDIR)/libtestpkg.a
+      PKG_LIBS = -L$(LIBDIR) -ltestpkg -lws2_32 -ladvapi32 -luserenv
+      
+      all: C_clean
+      
+      $(SHLIB): $(STATLIB)
+      
+      $(STATLIB):
+      	cargo build --target=$(TARGET) --lib --release --manifest-path=./rust/Cargo.toml
+      
+      C_clean:
+      	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS)
+      
+      clean:
+      	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS) rust/target
+
+---
+
+    Code
+      cat_file("src", "entrypoint.c")
+    Output
+      // We need to forward routine registration from C to Rust
+      // to avoid the linker removing the static library.
+      
+      void R_init_testpkg_extendr(void *dll);
+      
+      void R_init_testpkg(void *dll) {
+          R_init_testpkg_extendr(dll);
+      }
+
+---
+
+    Code
+      cat_file("src", "rust", "Cargo.toml")
+    Output
+      [package]
+      name = 'testpkg'
+      version = '0.1.0'
+      edition = '2018'
+      
+      [lib]
+      crate-type = [ 'staticlib' ]
+      
+      [dependencies]
+      extendr-api = '*'
+
+---
+
+    Code
+      cat_file("src", "rust", "src", "lib.rs")
+    Output
+      use extendr_api::prelude::*;
+      
+      /// Return string `"Hello world!"` to R.
+      /// @export
+      #[extendr]
+      fn hello_world() -> &'static str {
+          "Hello world!"
+      }
+      
+      // Macro to generate exports.
+      // This ensures exported functions are registered with R.
+      // See corresponding C code in `entrypoint.c`.
+      extendr_module! {
+          mod testpkg;
+          fn hello_world;
+      }
+

--- a/tests/testthat/_snaps/use_extendr.md
+++ b/tests/testthat/_snaps/use_extendr.md
@@ -4,13 +4,13 @@
       use_extendr()
     Message <message>
       v Creating src/rust/src.
-      v Writing file src/entrypoint.c.
-      v Writing file src/Makevars.
-      v Writing file src/Makevars.win.
-      v Writing file src/.gitignore.
-      v Writing file src/rust/Cargo.toml.
-      v Writing file src/rust/src/lib.rs.
-      v Writing wrappers to R/extendr-wrappers.R.
+      v Writing 'src/entrypoint.c'
+      v Writing 'src/Makevars'
+      v Writing 'src/Makevars.win'
+      v Writing 'src/.gitignore'
+      v Writing 'src/rust/Cargo.toml'.
+      v Writing 'src/rust/src/lib.rs'
+      v Writing 'R/extendr-wrappers.R'
       v Finished configuring extendr for package testpkg.
       * Please update the system requirement in DESCRIPTION file.
       * Please run `rextendr::document()` for changes to take effect.
@@ -24,6 +24,7 @@
       #' @usage NULL
       #' @useDynLib testpkg, .registration = TRUE
       NULL
+      
       #' Return string `"Hello world!"` to R.
       #' @export
       hello_world <- function() .Call(wrap__hello_world)

--- a/tests/testthat/test-helper-functions.R
+++ b/tests/testthat/test-helper-functions.R
@@ -280,7 +280,7 @@ test_that("`write_file()` does the same as `brio::write_lines()`", {
   brio::write_lines(text, temp_file_brio)
   # `write_file()` produces a {cli} message
   withr::local_options(usethis.quiet = FALSE)
-  expect_message(write_file(text, temp_file_rxr), "Writing file")
+  expect_message(write_file(text, temp_file_rxr), "Writing")
 
   # Verifies file content
   expect_equal(readLines(temp_file_rxr), readLines(temp_file_brio))

--- a/tests/testthat/test-use_extendr.R
+++ b/tests/testthat/test-use_extendr.R
@@ -10,12 +10,16 @@ test_that("use_extendr() sets up extendr files correctly", {
   expect_true(dir.exists(file.path("src", "rust", "src")))
 
   # extendr files
-  expect_true(file.exists(file.path("R", "extendr-wrappers.R")))
-  expect_true(file.exists(file.path("src", "Makevars")))
-  expect_true(file.exists(file.path("src", "Makevars.win")))
-  expect_true(file.exists(file.path("src", "entrypoint.c")))
-  expect_true(file.exists(file.path("src", "rust", "Cargo.toml")))
-  expect_true(file.exists(file.path("src", "rust", "src", "lib.rs")))
+  cat_file <- function(...) {
+    cat(brio::read_file(file.path(...)))
+  }
+
+  expect_snapshot(cat_file("R", "extendr-wrappers.R"))
+  expect_snapshot(cat_file("src", "Makevars"))
+  expect_snapshot(cat_file("src", "Makevars.win"))
+  expect_snapshot(cat_file("src", "entrypoint.c"))
+  expect_snapshot(cat_file("src", "rust", "Cargo.toml"))
+  expect_snapshot(cat_file("src", "rust", "src", "lib.rs"))
 })
 
 test_that("use_extendr() does not set up packages with pre-existing src", {

--- a/tests/testthat/test-use_extendr.R
+++ b/tests/testthat/test-use_extendr.R
@@ -65,7 +65,7 @@ test_that("use_rextendr_template() works when usethis not available", {
     file.path("src", "rust", "src", "lib.rs")
   )
 
-  usethis_generated_templates <- purrr::map(files, brio::read_file)
+  usethis_generated_templates <- purrr::map(files, brio::read_lines)
 
   unlink("src", recursive = TRUE)
   unlink(file.path("R", "extendr-wrappers.R"))
@@ -77,7 +77,7 @@ test_that("use_rextendr_template() works when usethis not available", {
     .env = "rextendr"
   )
 
-  rextendr_generated_templates <- purrr::map(files, brio::read_file)
+  rextendr_generated_templates <- purrr::map(files, brio::read_lines)
 
   expect_identical(usethis_generated_templates, rextendr_generated_templates)
 })

--- a/tests/testthat/test-use_extendr.R
+++ b/tests/testthat/test-use_extendr.R
@@ -65,7 +65,7 @@ test_that("use_rextendr_template() works when usethis not available", {
     file.path("src", "rust", "src", "lib.rs")
   )
 
-  usethis_generated_templates <- lapply(files, brio::read_file)
+  usethis_generated_templates <- purrr::map(files, brio::read_file)
 
   unlink("src", recursive = TRUE)
   unlink(file.path("R", "extendr-wrappers.R"))
@@ -77,7 +77,7 @@ test_that("use_rextendr_template() works when usethis not available", {
     .env = "rextendr"
   )
 
-  rextendr_generated_templates <- lapply(files, brio::read_file)
+  rextendr_generated_templates <- purrr::map(files, brio::read_file)
 
   expect_identical(usethis_generated_templates, rextendr_generated_templates)
 })

--- a/tests/testthat/test-use_extendr.R
+++ b/tests/testthat/test-use_extendr.R
@@ -46,3 +46,38 @@ test_that("use_extendr() does not set up packages with pre-existing wrappers", {
 
   expect_false(created)
 })
+
+test_that("use_rextendr_template() works when usethis not available", {
+  path <- local_package("testpkg.wrap")
+  mockr::with_mock(
+    # mock that usethis installed
+    is_installed = function(...) TRUE,
+    use_extendr(),
+    .env = "rextendr"
+  )
+
+  files <- c(
+    file.path("R", "extendr-wrappers.R"),
+    file.path("src", "Makevars"),
+    file.path("src", "Makevars.win"),
+    file.path("src", "entrypoint.c"),
+    file.path("src", "rust", "Cargo.toml"),
+    file.path("src", "rust", "src", "lib.rs")
+  )
+
+  usethis_generated_templates <- lapply(files, brio::read_file)
+
+  unlink("src", recursive = TRUE)
+  unlink(file.path("R", "extendr-wrappers.R"))
+
+  mockr::with_mock(
+    # mock that usethis not installed
+    is_installed = function(...) FALSE,
+    use_extendr(),
+    .env = "rextendr"
+  )
+
+  rextendr_generated_templates <- lapply(files, brio::read_file)
+
+  expect_identical(usethis_generated_templates, rextendr_generated_templates)
+})


### PR DESCRIPTION
This PR refactors `use_extendr()` a bit more to use templates in the style of `usethis::use_template()`. When usethis is available, we just use that, and when it's not, we use a simplified version (`use_template()` is more robust but some of the protections that it has aren't strictly necessary here since we don't write at all if there are pre-existing files). 

Using this approach is more consistent with usethis, but I also find that templates are much easier to understand and maintain than hard-coded text in code.

This PR also adds mockr to `Suggests` to enable mocking of functions in tests. 

Finally closes #62 