### PR TITLE
Fix `rust_source()` examples

### DIFF
--- a/R/source.R
+++ b/R/source.R
@@ -55,12 +55,6 @@
 #' fn test( a: &str, b: i64) {
 #'     rprintln!("Data sent to Rust: {}, {}", a, b);
 #' }
-#'
-#' extendr_module! {
-#'     mod rextendr;
-#'     fn hello;
-#'     fn test;
-#' }
 #' )"
 #'
 #' rust_source(code = code)
@@ -82,13 +76,11 @@
 #'     html::push_html(&mut output, parser);
 #'     output
 #'   }
-#'
-#'   extendr_module! {
-#'     mod rextendr;
-#'     fn md_to_html;
-#'   }
 #' )"
-#' rust_source(code = code, dependencies = 'pulldown-cmark = "0.8"')
+#' rust_source(
+#'   code = code,
+#'   dependencies = list(`pulldown-cmark` = "0.8")
+#' )
 #'
 #' md_text <- "# The story of the fox
 #' The quick brown fox **jumps over** the lazy dog.

--- a/R/source.R
+++ b/R/source.R
@@ -120,13 +120,11 @@ rust_source <- function(file, code = NULL,
     # R console displays to the user informaion about compilation steps and
     # potenatial compilation errors.
     out <- ""
-
   } else {
 
     # `NULL` or `FALSE` intercepts standard output from `cargo`.
     # No compilation information is displayed to the user.
     out <- NULL
-
   }
 
   # copy rust code into src/lib.rs and determine library name

--- a/man/rust_eval.Rd
+++ b/man/rust_eval.Rd
@@ -33,12 +33,12 @@ rust_eval(
 
 # Rust code with return value
 rust_eval(
-  code = '
+  code = "
     let x = 5;
     let y = 7;
     let z = x * y;
     z // return to R; rust_eval() takes care of type conversion code
- '
+ "
 )
 }
 }

--- a/man/rust_source.Rd
+++ b/man/rust_source.Rd
@@ -99,12 +99,6 @@ fn hello() -> &'static str {
 fn test( a: &str, b: i64) {
     rprintln!("Data sent to Rust: {}, {}", a, b);
 }
-
-extendr_module! {
-    mod rextendr;
-    fn hello;
-    fn test;
-}
 )"
 
 rust_source(code = code)
@@ -126,13 +120,11 @@ code <- r"(
     html::push_html(&mut output, parser);
     output
   }
-
-  extendr_module! {
-    mod rextendr;
-    fn md_to_html;
-  }
 )"
-rust_source(code = code, dependencies = 'pulldown-cmark = "0.8"')
+rust_source(
+  code = code,
+  dependencies = list(`pulldown-cmark` = "0.8")
+)
 
 md_text <- "# The story of the fox
 The quick brown fox **jumps over** the lazy dog.


### PR DESCRIPTION
Currently, the examples written in the docs of `rust_source()` are invalid, because they were written for an older version of {rextendr}, which was not able to generate `extendr_module!` and accepted `Cargo.toml` entries as plain text.
<details>

https://github.com/extendr/rextendr/blob/9088db8a96b678131aec5c058fd303f7d8ee9e29/R/source.R#L41-L98

</details>

This PR fixes this issue.

<details>
<summary>Before</summary>

``` r
code <- r"(
#[extendr]
fn hello() -> &'static str {
    "Hello, world!"
}

#[extendr]
fn test( a: &str, b: i64) {
    rprintln!("Data sent to Rust: {}, {}", a, b);
}

extendr_module! {
    mod rextendr;
    fn hello;
    fn test;
}
)"

rextendr::rust_source(code = code)
#> i build directory: 'C:\Users\[redacted]\AppData\Local\Temp\RtmpKypJ4o\file589850301b71'
#> Error: Rust code could not be compiled successfully. Aborting.
hello()
#> Error in hello(): could not find function "hello"
test("a string", 42)
#> Error in test("a string", 42): could not find function "test"
```

``` r
code <- r"(
  use pulldown_cmark::{Parser, Options, html};

  #[extendr]
  fn md_to_html(input: &str) -> String {
    let mut options = Options::empty();
    options.insert(Options::ENABLE_TABLES);
    let parser = Parser::new_ext(input, options);
    let mut output = String::new();
    html::push_html(&mut output, parser);
    output
  }

  extendr_module! {
    mod rextendr;
    fn md_to_html;
  }
)"
rextendr::rust_source(code = code, dependencies = 'pulldown-cmark = "0.8"')
#> i build directory: 'C:\Users\[redacted]\AppData\Local\Temp\RtmpIXLi1Y\file22e419674f72'
#> Error: Object cannot be serialzied.
#> x Unnamed arguments found at position(s): `2`.
#> i List values should have names.

md_text <- "# The story of the fox
The quick brown fox **jumps over** the lazy dog.
The quick *brown fox* jumps over the lazy dog."

md_to_html(md_text)
#> Error in md_to_html(md_text): could not find function "md_to_html"
```

<sup>Created on 2021-05-12 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>


</details>

<details>
<summary>After</summary>


``` r
code <- r"(
#[extendr]
fn hello() -> &'static str {
    "Hello, world!"
}

#[extendr]
fn test( a: &str, b: i64) {
    rprintln!("Data sent to Rust: {}, {}", a, b);
}
)"

rextendr::rust_source(code = code)
#> i build directory: 'C:\Users\[redacted]\AppData\Local\Temp\RtmpuAB2Zk\file440c10045ea'
#> v Writing 'C:/Users/[redacted]/AppData/Local/Temp/RtmpuAB2Zk/file440c10045ea/target/extendr_wrappers.R'.
hello()
#> [1] "Hello, world!"
test("a string", 42)
#> Data sent to Rust: a string, 42

 code <- r"(
   use pulldown_cmark::{Parser, Options, html};

   #[extendr]
   fn md_to_html(input: &str) -> String {
     let mut options = Options::empty();
     options.insert(Options::ENABLE_TABLES);
     let parser = Parser::new_ext(input, options);
     let mut output = String::new();
     html::push_html(&mut output, parser);
     output
   }
 )"
 rextendr::rust_source(
   code = code,
   dependencies = list(`pulldown-cmark` = "0.8")
  )
#> i build directory: 'C:\Users\[redacted]\AppData\Local\Temp\RtmpuAB2Zk\file440c10045ea'
#> v Writing 'C:/Users/[redacted]/AppData/Local/Temp/RtmpuAB2Zk/file440c10045ea/target/extendr_wrappers.R'.

 md_text <- "# The story of the fox
 The quick brown fox **jumps over** the lazy dog.
 The quick *brown fox* jumps over the lazy dog."

 md_to_html(md_text)
#> [1] "<h1>The story of the fox</h1>\n<p>The quick brown fox <strong>jumps over</strong> the lazy dog.\nThe quick <em>brown fox</em> jumps over the lazy dog.</p>\n"
```

<sup>Created on 2021-05-12 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>

</details>