### PR TITLE
Removes `msys2` dependency

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -38,10 +38,8 @@ jobs:
           toolchain: ${{ matrix.config.rust-version }}
           default: true
 
-      # Uses @master branch to address rtools path issue
-      # https://github.com/r-lib/actions/issues/228
       - name: Set up R
-        uses: r-lib/actions/setup-r@master
+        uses: r-lib/actions/setup-r@v1
         with:
           r-version: ${{ matrix.config.r }}
           windows-path-include-mingw: false

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -67,8 +67,6 @@ jobs:
         run: |
           rustup target add x86_64-pc-windows-gnu
           rustup target add i686-pc-windows-gnu
-          echo "C:\msys64\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append 
-          echo "C:\msys64\mingw32\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
         shell: pwsh
 
       - name: Configure Linux


### PR DESCRIPTION
Closes #91.
I have verified this behavior twice:
- Using a VBox Windows 10 VM with VC++ Build Tools, Rust/Cargo, R-4.1.0 and Rtools40v2 (clean installation, no msys2 on the system)
- Using the [same CI with reset cache](https://github.com/Ilia-Kosenkov/rextendr/runs/2774126052?check_suite_focus=true#step:11:5), check the output [here](https://github.com/Ilia-Kosenkov/rextendr/runs/2774126052?check_suite_focus=true#step:11:1040)
I used an example by @yutannihilation  posted in #91, where the path was forced to point only to R and cargo binaries and rtools.
Under these conditions, the CI successfully executes `devtools::test()`, which means the Rust code is indeed compiled successfully.

This can be separately verified by any Windows user by purging `msys2` (or removing it from `PATH`) and then running something like `rextendr::rust_eval("5i32 + 10i32")`.