### PR TITLE
rextendr 0.2.0 released to CRAN

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -9,3 +9,4 @@
 ^principles\.md$
 ^CODE-OF-CONDUCT\.md$
 ^CONTRIBUTING\.md$
+^cran-comments\.md$

--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -10,3 +10,4 @@
 ^CODE-OF-CONDUCT\.md$
 ^CONTRIBUTING\.md$
 ^cran-comments\.md$
+^CRAN-RELEASE$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rextendr
 Title: Call Rust Code from R using the 'extendr' Crate
-Version: 0.1.0.9000
+Version: 0.2.0
 Authors@R: 
     c(person(given = "Claus O.",
              family = "Wilke",
@@ -35,7 +35,7 @@ Description: Call Rust code from R. This package provides functions to
     allow easy interfacing with C++ code. Under the hood, the package uses
     the Rust 'extendr' crate to do all the heavy lifting.
 License: MIT + file LICENSE
-URL: https://github.com/extendr/rextendr
+URL: https://extendr.github.io/rextendr/
 BugReports: https://github.com/extendr/rextendr/issues
 Depends:
     R (>= 4.0)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,10 +30,10 @@ Authors@R:
              role = "aut",
              email = "malcolmbarrett@gmail.com",
              comment = c(ORCID = "0000-0003-0299-5825")))
-Description: Call Rust code from R. This package provides functions to
-    compile and load Rust code from R, similar to how 'Rcpp' or 'cpp11'
-    allow easy interfacing with C++ code. Under the hood, the package uses
-    the Rust 'extendr' crate to do all the heavy lifting.
+Description: Provides functions to compile and load Rust code from R, similar
+    to how 'Rcpp' or 'cpp11' allow easy interfacing with C++ code. Also provides
+    helper functions to create R packages that use Rust code. Under the hood,
+    the Rust crate 'extendr' is used to do all the heavy lifting.
 License: MIT + file LICENSE
 URL: https://extendr.github.io/rextendr/
 BugReports: https://github.com/extendr/rextendr/issues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -67,7 +67,6 @@ VignetteBuilder:
 Config/testthat/edition: 3
 Config/testthat/parallel: true
 Encoding: UTF-8
-LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.1
 SystemRequirements: Rust 'cargo'; the crate 'libR-sys' must compile

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,3 @@
+# rextendr 0.2.0
+
+First official release.

--- a/R/make_module_macro.R
+++ b/R/make_module_macro.R
@@ -9,6 +9,7 @@
 #' for generics.
 #' @param code Character vector containing Rust code.
 #' @param module_name Module name
+#' @return Character vector holding the contents of the generated macro statement.
 #' @keywords internal
 #' @export
 make_module_macro <- function(code, module_name = "rextendr") {

--- a/R/register_extendr.R
+++ b/R/register_extendr.R
@@ -3,12 +3,14 @@
 #' This function generates wrapper code corresponding to the extendr module
 #' for an R package. This is useful in package development, where we generally
 #' want appropriate R code wrapping the Rust functions implemented via extendr.
+#' In most development settings, you will not want to call this function directly,
+#' but instead call `rextendr::document()`.
 #'
-#' To run `register_extendr()`, the R package containing extendr code must have
-#' previously been compiled and installed. If this condition is met, the
-#' wrapper code will be retrieved from the compiled Rust code and saved into
-#' `R/extendr-wrappers.R`. Afterwards, you will have to re-document and then
-#' re-install the package for the wrapper functions to take effect.
+#' The function `register_extendr()` compiles the package Rust code if
+#' required, and then the wrapper code is retrieved from the compiled
+#' Rust code and saved into `R/extendr-wrappers.R`. Afterwards, you will have
+#' to re-document and then re-install the package for the wrapper functions to
+#' take effect.
 #'
 #' @param path Path from which package root is looked up.
 #' @param quiet Logical indicating whether any progress messages should be
@@ -23,6 +25,7 @@
 #'     \item{`FALSE`}{never recompiles}
 #'   }
 #' @return (Invisibly) Path to the file containing generated wrappers.
+#' @seealso [rextendr::document()]
 #' @export
 register_extendr <- function(path = ".", quiet = FALSE, force = FALSE, compile = NA) {
   pkg_name <- pkg_name(path)

--- a/R/rextendr_document.R
+++ b/R/rextendr_document.R
@@ -7,6 +7,7 @@
 #' Specifically, it ensures that Rust code is recompiled (when necessary) and that
 #' up-to-date R wrappers are generated before re-generating the package documentation.
 #' @inheritParams devtools::document
+#' @return No return value, called for side effects.
 #' @export
 document <- function(pkg = ".", quiet = getOption("usethis.quiet", FALSE), roclets = NULL) {
   try_save_all(quiet = quiet)

--- a/R/source.R
+++ b/R/source.R
@@ -32,12 +32,12 @@
 #' @param cache_build Logical indicating whether builds should be cached between
 #'   calls to [rust_source()].
 #' @param quiet Logical indicating whether compile output should be generated or not.
-#' @param use_rtools Logical indicating whether to append path to Rtools
-#'   to the `PATH` variable on Windows using `RTOOLS40_HOME` environent variable
-#'   (if it is set). Appended path depends on the process architecture.
-#'   Does nothing on other platforms.
-#' @return The result from [dyn.load()], which is an object of class `DLLInfo`. See
-#'   [getLoadedDLLs()] for more details.
+#' @param use_rtools Logical indicating whether to append the path to Rtools
+#'   to the `PATH` variable on Windows using the `RTOOLS40_HOME` environment
+#'   variable (if it is set). The appended path depends on the process
+#'   architecture. Does nothing on other platforms.
+#' @return The result from [dyn.load()], which is an object of class `DLLInfo`.
+#'  See [getLoadedDLLs()] for more details.
 #' @examples
 #' \dontrun{
 #' # creating a single rust function

--- a/R/toml_serialization.R
+++ b/R/toml_serialization.R
@@ -3,8 +3,8 @@
 #' [to_toml()] can be used to build `Cargo.toml`.
 #' The cargo manifest can be represented in terms of
 #' R objects, allowing limited validation and syntax verification.
-#' This function converts mainfests written using R objects into
-#' toml represenation, applying basic formatting,
+#' This function converts manifests written using R objects into
+#' toml representation, applying basic formatting,
 #' which is ideal for generating cargo
 #' manifests at runtime.
 #'

--- a/README.Rmd
+++ b/README.Rmd
@@ -20,7 +20,7 @@ knitr::opts_chunk$set(
 [![R build
 status](https://github.com/extendr/rextendr/workflows/R-CMD-check/badge.svg)](https://github.com/extendr/rextendr/actions)
 [![CRAN status](https://www.r-pkg.org/badges/version/rextendr)](https://CRAN.R-project.org/package=rextendr)
-[![Lifecycle: experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://www.tidyverse.org/lifecycle/#experimental)
+[![Lifecycle: stable](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://lifecycle.r-lib.org/articles/stages.html#stable)
 <!-- badges: end -->
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ status](https://github.com/extendr/rextendr/workflows/R-CMD-check/badge.svg)](ht
 [![CRAN
 status](https://www.r-pkg.org/badges/version/rextendr)](https://CRAN.R-project.org/package=rextendr)
 [![Lifecycle:
-experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://www.tidyverse.org/lifecycle/#experimental)
+stable](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://lifecycle.r-lib.org/articles/stages.html#stable)
 <!-- badges: end -->
 
 ## Installation

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -11,6 +11,7 @@ reference:
 - title: Package development
   contents:
   - use_extendr
+  - document
   - register_extendr
 
 - title: Various utility functions

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,4 +1,6 @@
-This is the first submission of a package that enables calling Rust code from R and integrating Rust code into R packages.
+I have revised the package in response to the feedback on the previous submission:
+- All functions now have their return value documented.
+- The long-form description of the package no longer starts with "This package" or similar.
 
 ## Test environment
 * ubuntu 20.04, devel and release

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,3 +1,4 @@
+This is the first submission of a package that enables calling Rust code from R and integrating Rust code into R packages.
 
 ## Test environment
 * ubuntu 20.04, devel and release

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,0 +1,8 @@
+
+## Test environment
+* ubuntu 20.04, devel and release
+* windows, release
+* macOS, release
+
+## R CMD check results
+There were no ERRORs, WARNINGs, or NOTEs.

--- a/man/document.Rd
+++ b/man/document.Rd
@@ -16,6 +16,9 @@ package object.  See \code{\link[devtools:as.package]{as.package()}} for more in
 The default, \code{NULL}, uses the roxygen \code{roclets} option,
 which defaults to \code{c("collate", "namespace", "rd")}.}
 }
+\value{
+No return value, called for side effects.
+}
 \description{
 The function \code{rextendr::document()} updates the package documentation for an
 R package that uses \code{extendr} code, taking into account any changes that were

--- a/man/make_module_macro.Rd
+++ b/man/make_module_macro.Rd
@@ -11,6 +11,9 @@ make_module_macro(code, module_name = "rextendr")
 
 \item{module_name}{Module name}
 }
+\value{
+Character vector holding the contents of the generated macro statement.
+}
 \description{
 Read some Rust source code, find functions or implementations with the
 \verb{#[extendr]} attribute, and generate an \verb{extendr_module!} macro statement.

--- a/man/register_extendr.Rd
+++ b/man/register_extendr.Rd
@@ -30,11 +30,16 @@ default, generation is skipped when it's newer than the DLL).}
 This function generates wrapper code corresponding to the extendr module
 for an R package. This is useful in package development, where we generally
 want appropriate R code wrapping the Rust functions implemented via extendr.
+In most development settings, you will not want to call this function directly,
+but instead call \code{rextendr::document()}.
 }
 \details{
-To run \code{register_extendr()}, the R package containing extendr code must have
-previously been compiled and installed. If this condition is met, the
-wrapper code will be retrieved from the compiled Rust code and saved into
-\code{R/extendr-wrappers.R}. Afterwards, you will have to re-document and then
-re-install the package for the wrapper functions to take effect.
+The function \code{register_extendr()} compiles the package Rust code if
+required, and then the wrapper code is retrieved from the compiled
+Rust code and saved into \code{R/extendr-wrappers.R}. Afterwards, you will have
+to re-document and then re-install the package for the wrapper functions to
+take effect.
+}
+\seealso{
+\code{\link[=document]{document()}}
 }

--- a/man/rust_source.Rd
+++ b/man/rust_source.Rd
@@ -67,16 +67,16 @@ calls to \code{\link[=rust_source]{rust_source()}}.}
 
 \item{quiet}{Logical indicating whether compile output should be generated or not.}
 
-\item{use_rtools}{Logical indicating whether to append path to Rtools
-to the \code{PATH} variable on Windows using \code{RTOOLS40_HOME} environent variable
-(if it is set). Appended path depends on the process architecture.
-Does nothing on other platforms.}
+\item{use_rtools}{Logical indicating whether to append the path to Rtools
+to the \code{PATH} variable on Windows using the \code{RTOOLS40_HOME} environment
+variable (if it is set). The appended path depends on the process
+architecture. Does nothing on other platforms.}
 
 \item{...}{Other parameters handed off to \code{\link[=rust_source]{rust_source()}}.}
 }
 \value{
-The result from \code{\link[=dyn.load]{dyn.load()}}, which is an object of class \code{DLLInfo}. See
-\code{\link[=getLoadedDLLs]{getLoadedDLLs()}} for more details.
+The result from \code{\link[=dyn.load]{dyn.load()}}, which is an object of class \code{DLLInfo}.
+See \code{\link[=getLoadedDLLs]{getLoadedDLLs()}} for more details.
 }
 \description{
 \code{\link[=rust_source]{rust_source()}} compiles and loads a single Rust file for use in R. \code{\link[=rust_function]{rust_function()}}

--- a/man/to_toml.Rd
+++ b/man/to_toml.Rd
@@ -25,8 +25,8 @@ one line of the resulting output.
 \code{\link[=to_toml]{to_toml()}} can be used to build \code{Cargo.toml}.
 The cargo manifest can be represented in terms of
 R objects, allowing limited validation and syntax verification.
-This function converts mainfests written using R objects into
-toml represenation, applying basic formatting,
+This function converts manifests written using R objects into
+toml representation, applying basic formatting,
 which is ideal for generating cargo
 manifests at runtime.
 }


### PR DESCRIPTION
This is the version just released to CRAN: https://cran.r-project.org/web/packages/rextendr/index.html

I had to make a few minor fixes to get everything ready for release, mostly documentation.