### PR TITLE
Separate compilation and execution of Rust code in `rust_eval()`

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -3,7 +3,6 @@ on:
     branches:
       - main
       - master
-      - 'rust_eval'
   pull_request:
     branches:
       - main

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -3,6 +3,7 @@ on:
     branches:
       - main
       - master
+      - 'rust_eval'
   pull_request:
     branches:
       - main

--- a/R/eval.R
+++ b/R/eval.R
@@ -52,7 +52,16 @@ rust_eval_deferred <- function(code, env = parent.frame(), ...) {
     ui_throw("decoy function; should never be called.")
   }
 
+  # Snippet hash is constructed from the Rust source code and
+  # a unique identifier of the compiled dll.
+  # Every time any rust code is dynamically compiled,
+  # `the$count` is incremented.
+  # This ensures that any two (even bytewise-identical)
+  # Rust source code strings will have different
+  # hashes.
   snippet_hash <- rlang::hash(list(the$count, code))
+
+  # The unique hash is then used to generate unique function names
   fn_name <- glue("rextendr_rust_eval_fun_{snippet_hash}")
 
   # wrap code into Rust function

--- a/R/eval.R
+++ b/R/eval.R
@@ -85,9 +85,8 @@ fn {fn_name}() -> Result<Robj> {{
       )
     }
 
-
-    on.exit(dyn.unload(out[["path"]]), add = TRUE)
-    on.exit(rm(list = fn_name, envir = env), add = TRUE)
+    withr::defer(dyn.unload(out[["path"]]))
+    withr::defer(rm(list = fn_name, envir = env))
 
     result <- rlang::exec(fn_name, .env = env)
     if (has_no_return) {

--- a/R/eval.R
+++ b/R/eval.R
@@ -74,6 +74,11 @@ fn {fn_name}() -> Result<Robj> {{
 }}
 )")
 
+  # Attempt to figure out whether the Rust code returns a result or not,
+  # and make the result invisible or not accordingly. This regex approach
+  # is not perfect, but since it only affects the visibility of the result
+  # that's Ok. Worst case scenario a result that should be invisible is
+  # shown as visible.
   has_no_return <- grepl(".*;\\s*$", code, perl = TRUE)
 
   out <- rust_function(code = code_wrapped, env = env, ...)

--- a/R/eval.R
+++ b/R/eval.R
@@ -29,6 +29,21 @@
 #' }
 #' @export
 rust_eval <- function(code, env = parent.frame(), ...) {
+  rust_eval_deferred(code = code, env = env, ...)()
+}
+
+#' Evaluate Rust code (deferred)
+#'
+#' Compiles a chunk of Rust code and returns an R function,
+#' which, when called, executes Rust code.
+#' This allows to separate Rust code compilation and execution.
+#' The function can be called only once, it cleans up resources on exit,
+#' including loaded dll and sourced R wrapper.
+#'
+#' @inheritParams rust_eval
+#' @return \[`function()`\] An R function with no argumetns.
+#' @noRd
+rust_eval_deferred <- function(code, env = parent.frame(), ...) {
   # make sure code is given as a single character string
   code <- glue_collapse(code, sep = "\n")
 
@@ -37,27 +52,68 @@ rust_eval <- function(code, env = parent.frame(), ...) {
     ui_throw("decoy function; should never be called.")
   }
 
+  snippet_hash <- rlang::hash(list(the$count, code))
+  fn_name <- glue("rextendr_rust_eval_fun_{snippet_hash}")
+
   # wrap code into Rust function
   code_wrapped <- glue(r"(
-fn rextendr_rust_eval_fun() -> Result<Robj> {{
+fn {fn_name}() -> Result<Robj> {{
   let x = {{
     {code}
   }};
   Ok(x.into())
 }}
 )")
-  out <- rust_function(code = code_wrapped, ...)
-  result <- do.call(rextendr_rust_eval_fun, list(), envir = env)
-  dyn.unload(out[["path"]])
 
-  # Attempt to figure out whether the Rust code returns a result or not,
-  # and make the result invisible or not accordingly. This regex approach
-  # is not perfect, but since it only affects the visibility of the result
-  # that's Ok. Worst case scenario a result that should be invisible is
-  # shown as visible.
-  if (grepl(".*;\\s*$", code, perl = TRUE)) {
-    invisible(result)
+  has_no_return <- grepl(".*;\\s*$", code, perl = TRUE)
+
+  out <- rust_function(code = code_wrapped, env = env, ...)
+
+  generated_fn <- function() {
+    fn_handle <- get0(fn_name, envir = env, ifnotfound = NULL)
+    dll_handle <- find_loaded_dll(out[["name"]])
+    if (
+      rlang::is_null(fn_handle)  ||
+      rlang::is_null(dll_handle)
+    ) {
+      ui_throw(
+        "The Rust code fragment is no longer available for execution.",
+        details = c(
+          bullet_i("Code fragment can only be executed once."),
+          bullet_w("Make sure you are not re-using an outdated fragment.")
+        )
+      )
+    }
+
+
+    on.exit(dyn.unload(out[["path"]]), add = TRUE)
+    on.exit(rm(list = fn_name, envir = env), add = TRUE)
+
+    result <- rlang::exec(fn_name, .env = env)
+    if (has_no_return) {
+      invisible(result)
+    } else {
+      result
+    }
+  }
+
+  attr(generated_fn, "function_name") <- fn_name
+  attr(generated_fn, "dll_path") <- out[["path"]]
+
+  generated_fn
+}
+
+
+#' Find loaded dll by name
+#' @param name \[`string`\] Name of the dll (as returned by `dyn.load(...)[["name"]]`).
+#' @return \[`DllInfo`|`NULL`\] An object representing a loaded dll or
+#'   `NULL` if no such dll is loaded.
+#' @noRd
+find_loaded_dll <- function(name) {
+  dlls <- purrr::keep(getLoadedDLLs(), ~.x[["name"]] == name)
+  if (rlang::is_empty(dlls)) {
+    NULL
   } else {
-    result
+    dlls[[1]]
   }
 }

--- a/R/eval.R
+++ b/R/eval.R
@@ -73,8 +73,8 @@ fn {fn_name}() -> Result<Robj> {{
     fn_handle <- get0(fn_name, envir = env, ifnotfound = NULL)
     dll_handle <- find_loaded_dll(out[["name"]])
     if (
-      rlang::is_null(fn_handle)  ||
-      rlang::is_null(dll_handle)
+      rlang::is_null(fn_handle) ||
+        rlang::is_null(dll_handle)
     ) {
       ui_throw(
         "The Rust code fragment is no longer available for execution.",
@@ -109,7 +109,7 @@ fn {fn_name}() -> Result<Robj> {{
 #'   `NULL` if no such dll is loaded.
 #' @noRd
 find_loaded_dll <- function(name) {
-  dlls <- purrr::keep(getLoadedDLLs(), ~.x[["name"]] == name)
+  dlls <- purrr::keep(getLoadedDLLs(), ~ .x[["name"]] == name)
   if (rlang::is_empty(dlls)) {
     NULL
   } else {

--- a/tests/testthat/test-eval.R
+++ b/tests/testthat/test-eval.R
@@ -5,3 +5,73 @@ test_that("`rust_eval()` works", {
   expect_equal(rust_eval("let _ = 2 + 2;"), NULL)
   expect_invisible(rust_eval("let _ = 2 + 2;"))
 })
+
+# Test if multiple Rust chunks can be compiled and then executed
+# in the order of compilation.
+#
+# Generate `n` integers (1..n) and then compile Rust chunks that
+# return `n` as `i32`.
+# Collect all deferred handles first, and then execute them in
+# the the order of compilation.
+# Returned integer values should be identical to the input sequence.
+test_that("multiple `rust_eval_deferred()` work correctly", {
+  provided_values <- seq_len(5)
+  deferred_handles <- purrr::map(
+    provided_values,
+    ~rust_eval_deferred(glue::glue("{.x}i32"))
+  )
+
+  obtained_values <- purrr::map_int(deferred_handles, ~(.x)())
+
+  testthat::expect_equal(
+    obtained_values,
+    provided_values
+  )
+})
+
+
+# Test if multiple Rust chunks can be compiled and then executed
+# in the reverse order. This ensures that the order of compilation and
+# execution does not matter.
+#
+# Generate `n` integers (1..n) and then compile Rust chunks that
+# return `n` as `i32`.
+# Collect all deferred handles first, and then execute them in
+# the the reverse order.
+# Returned integer values should be identical to the reversed input sequence.
+test_that("multiple `rust_eval_deferred()` work correctly in reverse order", {
+  provided_values <- seq_len(5)
+
+  deferred_handles <- purrr::map(
+    provided_values,
+     ~rust_eval_deferred(glue::glue("{.x}i32"))
+  )
+
+  deferred_handles <- rev(deferred_handles)
+
+  obtained_values <- purrr::map_int(deferred_handles, ~(.x)())
+
+  testthat::expect_equal(
+    obtained_values,
+    rev(provided_values)
+  )
+})
+
+# Test if the same Rust chunk can be executed multiple times.
+#
+# After compilation, the Rust chunk can be executed only once, after which
+# all associated resources are freed.
+# First, compile a simple Rust expression returning an `i32` value.
+# Second, execute it once and compare returned value to expected value.
+# Third, attempt to execute the same compiled piece of code and
+# observe an error.
+test_that("`rust_eval_deferred()` disallows multiple executions of the same chunk", {
+  handle <- rust_eval_deferred("5i32 + 6i32")
+
+  testthat::expect_equal(handle(), 5L + 6L)
+  testthat::expect_error(
+    handle(),
+    "The Rust code fragment is no longer available for execution."
+  )
+
+})

--- a/tests/testthat/test-eval.R
+++ b/tests/testthat/test-eval.R
@@ -18,10 +18,10 @@ test_that("multiple `rust_eval_deferred()` work correctly", {
   provided_values <- seq_len(5)
   deferred_handles <- purrr::map(
     provided_values,
-    ~rust_eval_deferred(glue::glue("{.x}i32"))
+    ~ rust_eval_deferred(glue::glue("{.x}i32"))
   )
 
-  obtained_values <- purrr::map_int(deferred_handles, ~(.x)())
+  obtained_values <- purrr::map_int(deferred_handles, ~ (.x)())
 
   testthat::expect_equal(
     obtained_values,
@@ -44,12 +44,12 @@ test_that("multiple `rust_eval_deferred()` work correctly in reverse order", {
 
   deferred_handles <- purrr::map(
     provided_values,
-     ~rust_eval_deferred(glue::glue("{.x}i32"))
+    ~ rust_eval_deferred(glue::glue("{.x}i32"))
   )
 
   deferred_handles <- rev(deferred_handles)
 
-  obtained_values <- purrr::map_int(deferred_handles, ~(.x)())
+  obtained_values <- purrr::map_int(deferred_handles, ~ (.x)())
 
   testthat::expect_equal(
     obtained_values,
@@ -73,7 +73,6 @@ test_that("`rust_eval_deferred()` disallows multiple executions of the same chun
     handle(),
     "The Rust code fragment is no longer available for execution."
   )
-
 })
 
 # Test if `rust_eval_deferred()` correctly cleans up environment.
@@ -90,12 +89,12 @@ test_that("`rust_eval_deferred()` environment cleanup", {
   dll_path <- attr(handle, "dll_path")
 
   testthat::expect_true(exists(fn_name))
-  dlls <- purrr::keep(getLoadedDLLs(), ~.x[["path"]] == dll_path)
+  dlls <- purrr::keep(getLoadedDLLs(), ~ .x[["path"]] == dll_path)
   testthat::expect_length(dlls, 1L)
 
   testthat::expect_equal(handle(), 42L)
 
   testthat::expect_false(exists(fn_name))
-  dlls <- purrr::keep(getLoadedDLLs(), ~.x[["path"]] == dll_path)
+  dlls <- purrr::keep(getLoadedDLLs(), ~ .x[["path"]] == dll_path)
   testthat::expect_length(dlls, 0L)
 })

--- a/tests/testthat/test-eval.R
+++ b/tests/testthat/test-eval.R
@@ -11,8 +11,8 @@ test_that("`rust_eval()` works", {
 #
 # Generate `n` integers (1..n) and then compile Rust chunks that
 # return `n` as `i32`.
-# Collect all deferred handles first, and then execute them in
-# the the order of compilation.
+# Collect all deferred handles first, then execute them in
+# the order of compilation.
 # Returned integer values should be identical to the input sequence.
 test_that("multiple `rust_eval_deferred()` work correctly", {
   provided_values <- seq_len(5)
@@ -32,12 +32,12 @@ test_that("multiple `rust_eval_deferred()` work correctly", {
 
 # Test if multiple Rust chunks can be compiled and then executed
 # in the reverse order. This ensures that the order of compilation and
-# execution does not matter.
+# execution do not affect each other.
 #
 # Generate `n` integers (1..n) and then compile Rust chunks that
 # return `n` as `i32`.
-# Collect all deferred handles first, and then execute them in
-# the the reverse order.
+# Collect all deferred handles first, then execute them in
+# the reverse order.
 # Returned integer values should be identical to the reversed input sequence.
 test_that("multiple `rust_eval_deferred()` work correctly in reverse order", {
   provided_values <- seq_len(5)

--- a/tests/testthat/test-eval.R
+++ b/tests/testthat/test-eval.R
@@ -98,3 +98,26 @@ test_that("`rust_eval_deferred()` environment cleanup", {
   dlls <- purrr::keep(getLoadedDLLs(), ~ .x[["path"]] == dll_path)
   testthat::expect_length(dlls, 0L)
 })
+
+
+# Test that wrapper function names are unique even for identical Rust source
+#
+# Use the same string to compile two Rust chunks.
+# Compare wrapper function names and dll paths (should be unequal).
+# Execute both chunks and test results (should be equal).
+test_that("`rust_eval_deferred()` generates unique function names", {
+  rust_code <- "42f64"
+
+  handle_1 <- rust_eval_deferred(rust_code)
+  handle_2 <- rust_eval_deferred(rust_code)
+
+  testthat::expect_false(
+    attr(handle_1, "function_name") == attr(handle_2, "function_name")
+  )
+
+  testthat::expect_false(
+    attr(handle_1, "dll_path") == attr(handle_2, "dll_path")
+  )
+
+  testthat::expect_equal(handle_1(), handle_2())
+})


### PR DESCRIPTION
Closes #123.

In the current version, `rextendr::rust_eval("some code")` compiles and immediately executes code.
I introduce `rust_eval_deferred()`, an internal function that compiles the code but does not execute it.
Instead, it returns a function that can be called once to execute Rust code and obtain the result. After the first invocation, 
this R function cleans up resources, unloads dll and removes R wrapper function from R environment.

Right now there can be at most one compiled chunk at any time (because once created, it is immediately consumed), so there is no problem with multiple dlls or name overlap. With deferred execution there is a possibility of first compiling several pieces of rust code and then executing them in arbitrary order (though not available through the public API). To address this, I use `rlang::hash()` to compute a unique hash of the input code and dll name (or, rather, a proxy to dll name) and append this hash to the function name. As a result, every time a new code piece is compiled, it gets a unique dll (as was before) and a unique handle on R side. Now this becomes possible:
```R
x <- rust_eval_deferred("10i32") # code compiled and loaded
y <- rust_eval_deferred("20i32") # code compiled and loaded

y() # execute second fragment and free resources
#> 20
x() # execute first fragment and free resources
#> 10
```

This behavior is required for improving `{knitr}` engine and, ultimately, for capturing cargo compilation errors that I am working on. Other potential use cases may emerge in the future.

To emphasize, this **does not** change public API or observed behavior of `{rextendr}`.

I wrote a bunch of tests to verify the execution of multiple deferred chunks in different orders and their resource cleanup.