### PR TITLE
Cleanup of minor issues

### DIFF
--- a/R/eval.R
+++ b/R/eval.R
@@ -47,11 +47,6 @@ rust_eval_deferred <- function(code, env = parent.frame(), ...) {
   # make sure code is given as a single character string
   code <- glue_collapse(code, sep = "\n")
 
-  # define to make R code check happy; is not used
-  rextendr_rust_eval_fun <- function() {
-    ui_throw("decoy function; should never be called.")
-  }
-
   # Snippet hash is constructed from the Rust source code and
   # a unique identifier of the compiled dll.
   # Every time any rust code is dynamically compiled,

--- a/R/knitr_engine.R
+++ b/R/knitr_engine.R
@@ -20,7 +20,7 @@ eng_extendrsrc <- function(options) {
 
 eng_impl <- function(options, rextendr_fun) {
   if (!requireNamespace("knitr", quietly = TRUE)) {
-    ui_throw("The knitr package is required to run the extendr chunk engine.")
+    ui_throw("The {.pkg knitr} package is required to run the extendr chunk engine.")
   }
 
   if (!is.null(options$preamble)) {

--- a/R/source.R
+++ b/R/source.R
@@ -371,7 +371,7 @@ get_build_dir <- function(cache_build) {
     dir.create(dir)
     dir.create(file.path(dir, "R"))
     dir.create(file.path(dir, "src"))
-    the$build_dir <- dir
+    the$build_dir <- normalizePath(dir, winslash = "/")
   }
   the$build_dir
 }


### PR DESCRIPTION
This PR addresses small issues in string formatting.

1. [Windows] when dynamically compiling Rust code, the build directory was displayed to the user using backslashes (likes `C:\path\to\temp\dir`). However, by convention we use forward slashes everywhere, so I changed it to be consistent with all other displayed paths. Forward slash notation allows to copy-paste paths as is, backslashes are treated as escapes sequences and often require additional escaping.
2. [Follow up to #125] A function in `rust_eval_deparse()` was previously declared to please R CMD check, but is no longer used. I missed this yesterday when pushed PR. It is now safely removed.
3.  If `{knitr}` is absent, an error message is displayed if `eng_impl()` is somehow invoked. I replaced `"knitr"` with `"{.pkg knitr}"`, which uses inline markdown to highlight this is a package.