### PR TITLE
Adds support of `features` in `rust_source`

### DIFF
--- a/R/source.R
+++ b/R/source.R
@@ -18,6 +18,8 @@
 #'  such as `"nightly"`, or (on Windows) `"stable-msvc"`.
 #' @param extendr_deps Versions of `extendr-*` crates. Defaults to
 #'   \code{list(`extendr-api` = "*")}.
+#' @param features List of features that control conditional compilation and 
+#'   optional dependencies.
 #' @param env The R environment in which the wrapping functions will be defined.
 #' @param use_extendr_api Logical indicating whether
 #'   `use extendr_api::prelude::*;` should be added at the top of the Rust source
@@ -96,6 +98,7 @@ rust_source <- function(file, code = NULL,
                         profile = c("dev", "release"),
                         toolchain = getOption("rextendr.toolchain"),
                         extendr_deps = getOption("rextendr.extendr_deps"),
+                        features = NULL,
                         env = parent.frame(),
                         use_extendr_api = TRUE,
                         generate_module_macro = TRUE,
@@ -155,7 +158,8 @@ rust_source <- function(file, code = NULL,
     libname = libname,
     dependencies = dependencies,
     patch.crates_io = patch.crates_io,
-    extendr_deps = extendr_deps
+    extendr_deps = extendr_deps,
+    features = features
   )
   brio::write_lines(cargo.toml_content, file.path(dir, "Cargo.toml"))
 
@@ -300,7 +304,8 @@ invoke_cargo <- function(toolchain, specific_target, dir, profile,
 generate_cargo.toml <- function(libname = "rextendr",
                                 dependencies = NULL,
                                 patch.crates_io = NULL,
-                                extendr_deps = NULL) {
+                                extendr_deps = NULL,
+                                features = NULL) {
   to_toml(
     package = list(
       name = libname,
@@ -314,7 +319,8 @@ generate_cargo.toml <- function(libname = "rextendr",
       extendr_deps,
       dependencies
     ),
-    `patch.crates-io` = patch.crates_io
+    `patch.crates-io` = patch.crates_io,
+    features = features
   )
 }
 

--- a/R/toml_serialization.R
+++ b/R/toml_serialization.R
@@ -187,13 +187,17 @@ format_toml_atomic <- function(x,
                                ...,
                                .top_level = FALSE,
                                .formatter) {
+  # Cache dimensions because slicing drops attributes
+  dims <- dim(x)
+  x <- x[!is.na(x)]
   len <- length(x)
-  if (len == 0L || (len == 1L && isTRUE(is.na(x)))) {
+  
+  if (len == 0L) {
     "[ ]"
   } else {
     formatter <- as_function(.formatter)
     items <- glue_collapse(formatter(x, ...), ", ")
-    if (len > 1L || !is.null(dim(x))) {
+    if (len > 1L || !is.null(dims)) {
       items <- glue("[ {items} ]")
     }
     # Ensure type-stability

--- a/R/toml_serialization.R
+++ b/R/toml_serialization.R
@@ -187,12 +187,13 @@ format_toml_atomic <- function(x,
                                ...,
                                .top_level = FALSE,
                                .formatter) {
-  if (length(x) == 0L) {
+  len <- length(x)
+  if (len == 0L || (len == 1L && isTRUE(is.na(x)))) {
     "[ ]"
   } else {
     formatter <- as_function(.formatter)
     items <- glue_collapse(formatter(x, ...), ", ")
-    if (length(x) > 1L || !is.null(dim(x))) {
+    if (len > 1L || !is.null(dim(x))) {
       items <- glue("[ {items} ]")
     }
     # Ensure type-stability

--- a/man/rust_source.Rd
+++ b/man/rust_source.Rd
@@ -14,6 +14,7 @@ rust_source(
   profile = c("dev", "release"),
   toolchain = getOption("rextendr.toolchain"),
   extendr_deps = getOption("rextendr.extendr_deps"),
+  features = NULL,
   env = parent.frame(),
   use_extendr_api = TRUE,
   generate_module_macro = TRUE,
@@ -47,6 +48,9 @@ such as \code{"nightly"}, or (on Windows) \code{"stable-msvc"}.}
 
 \item{extendr_deps}{Versions of \verb{extendr-*} crates. Defaults to
 \code{list(`extendr-api` = "*")}.}
+
+\item{features}{List of features that control conditional compilation and
+optional dependencies.}
 
 \item{env}{The R environment in which the wrapping functions will be defined.}
 

--- a/tests/testthat/test-toml.R
+++ b/tests/testthat/test-toml.R
@@ -41,6 +41,7 @@ test_that("`toml` is generated correctly", {
       y = c("1", NA_character_, "2")
     ),
     single_row_array = data.frame(x = 1),
+    features = list(ndarray = NA),  # `NA` gets converted to empty array `[ ]`
     .str_as_literal = FALSE
   )
 
@@ -86,7 +87,10 @@ test_that("`toml` is generated correctly", {
     "y = \"2\"",
     "",
     "[[single_row_array]]",
-    "x = 1"
+    "x = 1",
+    "",
+    "[features]",
+    "ndarray = [ ]"
   )
 
   reference <- glue_collapse(reference, "\n")


### PR DESCRIPTION
Fixes #139. 
1. Enables `to_toml()` to produce `[ ]` when `NA` value is encountered, e.g. `list(features = list(ndarray = NA))`  translates into
```toml

[features]
ndarray = [ ]

```
2. `rust_source()` gains `features` parameter, defaulting to `NULL`, which, if specified, writes provided values under `features]` section in `Cargo.toml`. Allows enabling `extendr` features like `ndarray` usage.