### PR TITLE
Handle #[extendr] attributes with empty parentheses

### DIFF
--- a/R/find_exports.R
+++ b/R/find_exports.R
@@ -18,7 +18,7 @@ find_exports <- function(clean_lns) {
 
 # Finds lines which contain #[extendr] (allowing additional spaces)
 find_extendr_attrs_ids <- function(lns) {
-  which(stringi::stri_detect_regex(lns, r"{#\s*\[\s*extendr(\s*\(.+\))?\s*\]}"))
+  which(stringi::stri_detect_regex(lns, r"{#\s*\[\s*extendr(\s*\(.*\))?\s*\]}"))
 }
 
 # Gets function/module metadata from a subset of lines.

--- a/tests/testthat/test-make-module-macro.R
+++ b/tests/testthat/test-make-module-macro.R
@@ -128,9 +128,10 @@ test_that("Rust metadata capturing", {
       " #\t [ \textendr   ]",
       "#5",
       "#[extendr(some_option=true)]",
-      "#[extendr ( some_option =  true ) ]"
+      "#[extendr ( some_option =  true ) ]",
+      "#[extendr()]"
     )),
-    c(2L, 4L, 6L, 7L)
+    c(2L, 4L, 6L, 7L, 8L)
   )
 
   expect_equal(


### PR DESCRIPTION
Fix #138 