### PR TITLE
Specify stable-msvc toolchain explicitly on Windows

### DIFF
--- a/inst/templates/Makevars.win
+++ b/inst/templates/Makevars.win
@@ -1,4 +1,5 @@
 TARGET = $(subst 64,x86_64,$(subst 32,i686,$(WIN)))-pc-windows-gnu
+TOOLCHAIN = stable-msvc
 LIBDIR = ./rust/target/$(TARGET)/release
 STATLIB = $(LIBDIR)/lib{{{pkg_name}}}.a
 PKG_LIBS = -L$(LIBDIR) -l{{{pkg_name}}} -lws2_32 -ladvapi32 -luserenv
@@ -8,7 +9,7 @@ all: C_clean
 $(SHLIB): $(STATLIB)
 
 $(STATLIB):
-	cargo build --target=$(TARGET) --lib --release --manifest-path=./rust/Cargo.toml
+	cargo +$(TOOLCHAIN) build --target=$(TARGET) --lib --release --manifest-path=./rust/Cargo.toml
 
 C_clean:
 	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS)

--- a/tests/testthat/_snaps/use_extendr.md
+++ b/tests/testthat/_snaps/use_extendr.md
@@ -57,6 +57,7 @@
       cat_file("src", "Makevars.win")
     Output
       TARGET = $(subst 64,x86_64,$(subst 32,i686,$(WIN)))-pc-windows-gnu
+      TOOLCHAIN = stable-msvc
       LIBDIR = ./rust/target/$(TARGET)/release
       STATLIB = $(LIBDIR)/libtestpkg.a
       PKG_LIBS = -L$(LIBDIR) -ltestpkg -lws2_32 -ladvapi32 -luserenv
@@ -66,7 +67,7 @@
       $(SHLIB): $(STATLIB)
       
       $(STATLIB):
-      	cargo build --target=$(TARGET) --lib --release --manifest-path=./rust/Cargo.toml
+      	cargo +$(TOOLCHAIN) build --target=$(TARGET) --lib --release --manifest-path=./rust/Cargo.toml
       
       C_clean:
       	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS)


### PR DESCRIPTION
As we clearly state this on [the README of libR-sys](https://github.com/extendr/libR-sys/blame/c184e9de8683fa36bef03a2f95bce4ed91ebe769/README.md#L40), the toolchain should be `stable-msvc`. 

> When building for `Windows`, the default host should be `stable-msvc` and special `rust` targets should be added for compatibility with `R`:

So, I feel it's a good idea to specify it explicitly on `cargo build` as well. When there's no toolchain installed, the user gets this error and knows what's wrong. I don't know what happens when extendr is built with the gnu toolchain, but I think this should be a bit more helpful.

```
error: toolchain 'stable-x86_64-windows-pc-msvc' is not installed
```

One caveat is that the user cannot use another channel of the toolchain (e.g. `nightly-msvc`). But this can be manually set by changing `TOOLCHAIN` variable in `Makevars.win`, so I believe this won't be a problem