### PR TITLE
Knitr snapshot test

### DIFF
--- a/tests/data/test-knitr-engine-source-01.Rmd
+++ b/tests/data/test-knitr-engine-source-01.Rmd
@@ -1,0 +1,84 @@
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  message = FALSE,
+  collapse = TRUE,
+  comment = "#>"
+)
+```
+
+
+Basic use example:
+
+```{r}
+library(rextendr)
+
+# create a Rust function
+rust_function("fn add(a:f64, b:f64) -> f64 { a + b }")
+
+# call it from R
+add(2.5, 4.7)
+```
+
+The package also enables a new chunk type for knitr, `extendr`, which compiles and evaluates Rust code. For example, a code chunk such as this one:
+````markdown
+`r ''````{extendr}
+rprintln!("Hello from Rust!");
+
+let x = 5;
+let y = 7;
+let z = x*y;
+
+z
+```
+````
+
+would create the following output in the knitted document:
+```{extendr}
+rprintln!("Hello from Rust!");
+
+let x = 5;
+let y = 7;
+let z = x*y;
+
+z
+```
+
+Define variable `_x`:
+
+```{extendr chunk_x, eval = FALSE}
+let _x = 1;
+```
+
+Define variable `_y`:
+
+```{extendr chunk_y, eval = FALSE}
+let _y = 2;
+```
+
+Print:
+
+```{extendr out, preamble = c("chunk_x", "chunk_y")}
+rprintln!("x = {}, y = {}", _x, _y);
+```
+
+```{extendrsrc engine.opts = list(dependencies = list(`pulldown-cmark` = "0.8"))}
+use pulldown_cmark::{Parser, Options, html};
+
+#[extendr]
+fn md_to_html(input: &str) -> String {
+    let mut options = Options::empty();
+    options.insert(Options::ENABLE_TABLES);
+    let parser = Parser::new_ext(input, options);
+    let mut output = String::new();
+    html::push_html(&mut output, parser);
+    output
+}
+```
+
+```{r}
+md_text <- "# The story of the fox
+The quick brown fox **jumps over** the lazy dog.
+The quick *brown fox* jumps over the lazy dog."
+
+md_to_html(md_text)
+```

--- a/tests/testthat/_snaps/knitr-engine.md
+++ b/tests/testthat/_snaps/knitr-engine.md
@@ -1,0 +1,96 @@
+# Snapshot test of knitr-engine
+
+    Code
+      cat_file(output)
+    Output
+      
+      
+      
+      Basic use example:
+      
+      
+      ```r
+      library(rextendr)
+      
+      # create a Rust function
+      rust_function("fn add(a:f64, b:f64) -> f64 { a + b }")
+      
+      # call it from R
+      add(2.5, 4.7)
+      #> [1] 7.2
+      ```
+      
+      The package also enables a new chunk type for knitr, `extendr`, which compiles and evaluates Rust code. For example, a code chunk such as this one:
+      ````markdown
+      ```{extendr}
+      rprintln!("Hello from Rust!");
+      
+      let x = 5;
+      let y = 7;
+      let z = x*y;
+      
+      z
+      ```
+      ````
+      
+      would create the following output in the knitted document:
+      
+      ```rust
+      rprintln!("Hello from Rust!");
+      
+      let x = 5;
+      let y = 7;
+      let z = x*y;
+      
+      z
+      #> Hello from Rust!
+      #> [1] 35
+      ```
+      
+      Define variable `_x`:
+      
+      
+      ```rust
+      let _x = 1;
+      ```
+      
+      Define variable `_y`:
+      
+      
+      ```rust
+      let _y = 2;
+      ```
+      
+      Print:
+      
+      
+      ```rust
+      rprintln!("x = {}, y = {}", _x, _y);
+      #> x = 1, y = 2
+      ```
+      
+      
+      ```rust
+      use pulldown_cmark::{Parser, Options, html};
+      
+      #[extendr]
+      fn md_to_html(input: &str) -> String {
+          let mut options = Options::empty();
+          options.insert(Options::ENABLE_TABLES);
+          let parser = Parser::new_ext(input, options);
+          let mut output = String::new();
+          html::push_html(&mut output, parser);
+          output
+      }
+      ```
+      
+      
+      ```r
+      md_text <- "# The story of the fox
+      The quick brown fox **jumps over** the lazy dog.
+      The quick *brown fox* jumps over the lazy dog."
+      
+      md_to_html(md_text)
+      #> [1] "<h1>The story of the fox</h1>\n<p>The quick brown fox <strong>jumps over</strong> the lazy dog.\nThe quick <em>brown fox</em> jumps over the lazy dog.</p>\n"
+      ```
+

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -73,3 +73,10 @@ local_proj_set <- function(envir = parent.frame()) {
   withr::defer(usethis::proj_set(old_proj), envir = envir)
 }
 
+#' Helper function for snapshot testing.
+#' Wraps `brio::read_file` and writes content to output using `cat`.
+#' @param ... Path to the file being read.
+#' @noRd
+cat_file <- function(...) {
+  cat(brio::read_file(file.path(...)))
+}

--- a/tests/testthat/test-knitr-engine.R
+++ b/tests/testthat/test-knitr-engine.R
@@ -17,3 +17,12 @@ test_that("knitr-engine works", {
 
   expect_equal(eng_extendr(options), "## hello world!\n")
 })
+
+
+test_that("Snapshot test of knitr-engine", {
+  input <- file.path("../data/test-knitr-engine-source-01.Rmd")
+  output <- withr::local_file("snapshot_knitr_test.md")
+
+  knitr::knit(input, output)
+  expect_snapshot(cat_file(output))
+})

--- a/tests/testthat/test-use_extendr.R
+++ b/tests/testthat/test-use_extendr.R
@@ -9,11 +9,6 @@ test_that("use_extendr() sets up extendr files correctly", {
   expect_true(dir.exists(file.path("src", "rust")))
   expect_true(dir.exists(file.path("src", "rust", "src")))
 
-  # extendr files
-  cat_file <- function(...) {
-    cat(brio::read_file(file.path(...)))
-  }
-
   expect_snapshot(cat_file("R", "extendr-wrappers.R"))
   expect_snapshot(cat_file("src", "Makevars"))
   expect_snapshot(cat_file("src", "Makevars.win"))


### PR DESCRIPTION
Adding a `{knitr}` snapshot test of `extendr` and `extendrsrc` engines. 
The input for `knitr::knit()` is borrowed from examples presented throughout `{rextendr}` docs.

This will help us track any unintentional modifications to the knitted output while working on #113.

I put a sample `Rmd` into `./tests/data`, the placement can be discussed.
Storing of small test data chunks next to actual test code was suggested in section [14.4 of this article](https://r-pkgs.org/data.html).