### PR TITLE
Override `CARGO_TARGET_DIR` in `Makevars`

### DIFF
--- a/inst/templates/Makevars
+++ b/inst/templates/Makevars
@@ -1,8 +1,4 @@
-ifeq ($(CARGO_TARGET_DIR),)
 TARGET_DIR = ./rust/target
-else
-TARGET_DIR = $(CARGO_TARGET_DIR)
-endif
 LIBDIR = $(TARGET_DIR)/release
 STATLIB = $(LIBDIR)/lib{{{pkg_name}}}.a
 PKG_LIBS = -L$(LIBDIR) -l{{{pkg_name}}}
@@ -12,7 +8,7 @@ all: C_clean
 $(SHLIB): $(STATLIB)
 
 $(STATLIB):
-	cargo build --lib --release --manifest-path=./rust/Cargo.toml
+	cargo build --lib --release --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
 
 C_clean:
 	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS)

--- a/inst/templates/Makevars
+++ b/inst/templates/Makevars
@@ -1,4 +1,9 @@
-LIBDIR = ./rust/target/release
+ifeq ($(CARGO_TARGET_DIR),)
+TARGET_DIR = ./rust/target
+else
+TARGET_DIR = $(CARGO_TARGET_DIR)
+endif
+LIBDIR = $(TARGET_DIR)/release
 STATLIB = $(LIBDIR)/lib{{{pkg_name}}}.a
 PKG_LIBS = -L$(LIBDIR) -l{{{pkg_name}}}
 

--- a/inst/templates/Makevars.win
+++ b/inst/templates/Makevars.win
@@ -1,10 +1,6 @@
 TARGET = $(subst 64,x86_64,$(subst 32,i686,$(WIN)))-pc-windows-gnu
 TOOLCHAIN = stable-msvc
-ifeq ($(CARGO_TARGET_DIR),)
 TARGET_DIR = ./rust/target
-else
-TARGET_DIR = $(subst \,/,$(CARGO_TARGET_DIR))
-endif
 LIBDIR = $(TARGET_DIR)/$(TARGET)/release
 STATLIB = $(LIBDIR)/lib{{{pkg_name}}}.a
 PKG_LIBS = -L$(LIBDIR) -l{{{pkg_name}}} -lws2_32 -ladvapi32 -luserenv
@@ -14,7 +10,7 @@ all: C_clean
 $(SHLIB): $(STATLIB)
 
 $(STATLIB):
-	cargo +$(TOOLCHAIN) build --target=$(TARGET) --lib --release --manifest-path=./rust/Cargo.toml
+	cargo +$(TOOLCHAIN) build --target=$(TARGET) --lib --release --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
 
 C_clean:
 	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS)

--- a/inst/templates/Makevars.win
+++ b/inst/templates/Makevars.win
@@ -1,6 +1,11 @@
 TARGET = $(subst 64,x86_64,$(subst 32,i686,$(WIN)))-pc-windows-gnu
 TOOLCHAIN = stable-msvc
-LIBDIR = ./rust/target/$(TARGET)/release
+ifeq ($(CARGO_TARGET_DIR),)
+TARGET_DIR = ./rust/target
+else
+TARGET_DIR = $(subst \,/,$(CARGO_TARGET_DIR))
+endif
+LIBDIR = $(TARGET_DIR)/$(TARGET)/release
 STATLIB = $(LIBDIR)/lib{{{pkg_name}}}.a
 PKG_LIBS = -L$(LIBDIR) -l{{{pkg_name}}} -lws2_32 -ladvapi32 -luserenv
 

--- a/tests/testthat/_snaps/use_extendr.md
+++ b/tests/testthat/_snaps/use_extendr.md
@@ -34,7 +34,12 @@
     Code
       cat_file("src", "Makevars")
     Output
-      LIBDIR = ./rust/target/release
+      ifeq ($(CARGO_TARGET_DIR),)
+      TARGET_DIR = ./rust/target
+      else
+      TARGET_DIR = $(CARGO_TARGET_DIR)
+      endif
+      LIBDIR = $(TARGET_DIR)/release
       STATLIB = $(LIBDIR)/libtestpkg.a
       PKG_LIBS = -L$(LIBDIR) -ltestpkg
       
@@ -58,7 +63,12 @@
     Output
       TARGET = $(subst 64,x86_64,$(subst 32,i686,$(WIN)))-pc-windows-gnu
       TOOLCHAIN = stable-msvc
-      LIBDIR = ./rust/target/$(TARGET)/release
+      ifeq ($(CARGO_TARGET_DIR),)
+      TARGET_DIR = ./rust/target
+      else
+      TARGET_DIR = $(subst \,/,$(CARGO_TARGET_DIR))
+      endif
+      LIBDIR = $(TARGET_DIR)/$(TARGET)/release
       STATLIB = $(LIBDIR)/libtestpkg.a
       PKG_LIBS = -L$(LIBDIR) -ltestpkg -lws2_32 -ladvapi32 -luserenv
       

--- a/tests/testthat/_snaps/use_extendr.md
+++ b/tests/testthat/_snaps/use_extendr.md
@@ -34,11 +34,7 @@
     Code
       cat_file("src", "Makevars")
     Output
-      ifeq ($(CARGO_TARGET_DIR),)
       TARGET_DIR = ./rust/target
-      else
-      TARGET_DIR = $(CARGO_TARGET_DIR)
-      endif
       LIBDIR = $(TARGET_DIR)/release
       STATLIB = $(LIBDIR)/libtestpkg.a
       PKG_LIBS = -L$(LIBDIR) -ltestpkg
@@ -48,7 +44,7 @@
       $(SHLIB): $(STATLIB)
       
       $(STATLIB):
-      	cargo build --lib --release --manifest-path=./rust/Cargo.toml
+      	cargo build --lib --release --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
       
       C_clean:
       	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS)
@@ -63,11 +59,7 @@
     Output
       TARGET = $(subst 64,x86_64,$(subst 32,i686,$(WIN)))-pc-windows-gnu
       TOOLCHAIN = stable-msvc
-      ifeq ($(CARGO_TARGET_DIR),)
       TARGET_DIR = ./rust/target
-      else
-      TARGET_DIR = $(subst \,/,$(CARGO_TARGET_DIR))
-      endif
       LIBDIR = $(TARGET_DIR)/$(TARGET)/release
       STATLIB = $(LIBDIR)/libtestpkg.a
       PKG_LIBS = -L$(LIBDIR) -ltestpkg -lws2_32 -ladvapi32 -luserenv
@@ -77,7 +69,7 @@
       $(SHLIB): $(STATLIB)
       
       $(STATLIB):
-      	cargo +$(TOOLCHAIN) build --target=$(TARGET) --lib --release --manifest-path=./rust/Cargo.toml
+      	cargo +$(TOOLCHAIN) build --target=$(TARGET) --lib --release --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
       
       C_clean:
       	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS)


### PR DESCRIPTION
Fixes #145.
We hard-code the target directory in `Makevars` (the directory that contains compilation artefacts).
However, if `CARGO_TARGET_DIR` env var is set up, the artefacts are emitted in the subfolder of `CARGO_TARGET_DIR`, and `rextendr::document()` fails to link the library with the `entrypoint.o`. 
This fix checks if `CARGO_TARGET_DIR` is set up and updates relative paths accordingly.

