### PR TITLE
Separate compilation and evaluation in knitr

### DIFF
--- a/R/knitr_engine.R
+++ b/R/knitr_engine.R
@@ -47,14 +47,14 @@ eng_impl <- function(options, extendr_engine) {
   }
 
   ui_v("Compiling Rust extendr code chunk...")
-  compilation <- do.call(extendr_engine, c(list(code = code), opts))
+  compiled_code <- do.call(extendr_engine, c(list(code = code), opts))
 
-  if (isTRUE(options$eval) && rlang::is_function(compilation)) {
+  if (isTRUE(options$eval) && rlang::is_function(compiled_code)) {
     ui_v("Evaluating Rust extendr code chunk...")
 
     out <- utils::capture.output({
       result <- withVisible(
-        compilation()
+        compiled_code()
       )
       if (isTRUE(result$visible)) {
         print(result$value)

--- a/R/knitr_engine.R
+++ b/R/knitr_engine.R
@@ -18,7 +18,7 @@ eng_extendrsrc <- function(options) {
 
 
 
-eng_impl <- function(options, rextendr_fun) {
+eng_impl <- function(options, extendr_engine) {
   if (!requireNamespace("knitr", quietly = TRUE)) {
     ui_throw("The {.pkg knitr} package is required to run the extendr chunk engine.")
   }
@@ -47,7 +47,7 @@ eng_impl <- function(options, rextendr_fun) {
   }
 
   ui_v("Compiling Rust extendr code chunk...")
-  compilation <- do.call(rextendr_fun, c(list(code = code), opts))
+  compilation <- do.call(extendr_engine, c(list(code = code), opts))
 
   if (isTRUE(options$eval) && rlang::is_function(compilation)) {
     ui_v("Evaluating Rust extendr code chunk...")


### PR DESCRIPTION
The goal of this PR is to replace `rust_eval()` (which was reworked in #125)   with `rust_eval_deferred()`.
With the new function in place, we can separately compile and execute code, allowing greater flexibility for capturing `cargo` output and Rust's `stdout` during execution. 
