### PR TITLE
Add -lbcrypt

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -82,8 +82,6 @@ jobs:
         run: |
           remotes::install_deps(dependencies = TRUE)
           remotes::install_cran("rcmdcheck")
-          #TODO: remove this when testthat is fixed
-          remotes::install_version("testthat", "3.1.0")
         shell: Rscript {0}
 
       - name: Check

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -82,6 +82,8 @@ jobs:
         run: |
           remotes::install_deps(dependencies = TRUE)
           remotes::install_cran("rcmdcheck")
+          #TODO: remove this when testthat is fixed
+          remotes::install_version("testthat", "3.1.0")
         shell: Rscript {0}
 
       - name: Check

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -59,8 +59,8 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
-          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
+          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-2-${{ hashFiles('.github/depends.Rds') }}
+          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-2-
 
       - name: Configure Windows
         if: startsWith(runner.os, 'Windows')

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,12 +1,8 @@
 on:
   push:
-    branches:
-      - main
-      - master
+    branches: [main, master]
   pull_request:
-    branches:
-      - main
-      - master
+    branches: [main, master]
 
 name: R-CMD-check
 
@@ -14,86 +10,46 @@ jobs:
   R-CMD-check:
     runs-on: ${{ matrix.config.os }}
 
-    name: ${{ matrix.config.os }} (${{ matrix.config.r }} / ${{ matrix.config.rust-version }})
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
 
     strategy:
       fail-fast: false
       matrix:
         config:
           - {os: windows-latest, r: 'release', rust-version: 'stable-msvc'}
-          - {os: macOS-latest, r: 'release', rust-version: 'stable'}
-          - {os: ubuntu-20.04, r: 'release', rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
-          - {os: ubuntu-20.04, r: 'devel', rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
+          - {os: macOS-latest,   r: 'release', rust-version: 'stable'     }
+          - {os: ubuntu-20.04,   r: 'release', rust-version: 'stable'     }
+          - {os: ubuntu-20.04,   r: 'devel',   rust-version: 'stable'     }
 
     env:
-      R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
-      RSPM: ${{ matrix.config.rspm }}
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
 
     steps:
       - uses: actions/checkout@v2
-      
+
+      - uses: r-lib/actions/setup-pandoc@v1
+
       - name: Set up Rust
         uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.config.rust-version }}
           default: true
 
-      - name: Set up R
-        uses: r-lib/actions/setup-r@v1
-        with:
-          r-version: ${{ matrix.config.r }}
-          windows-path-include-mingw: false
-
-      - name: Set up pandoc
-        uses: r-lib/actions/setup-pandoc@v1
-
-      - name: Query dependencies
-        run: |
-          install.packages('remotes')
-          saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
-          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
-        shell: Rscript {0}
-
-      - name: Cache R packages (not Windows)
-        if: startsWith(runner.os, 'Windows') == false
-        uses: actions/cache@v2
-        with:
-          path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-2-${{ hashFiles('.github/depends.Rds') }}
-          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-2-
-
       - name: Configure Windows
         if: startsWith(runner.os, 'Windows')
         run: |
           rustup target add x86_64-pc-windows-gnu
           rustup target add i686-pc-windows-gnu
-        shell: pwsh
 
-      - name: Configure Linux
-        if: startsWith(runner.os, 'Linux')
-        run: |
-          while read -r cmd
-          do
-            eval sudo $cmd
-          done < <(Rscript -e 'writeLines(remotes::system_requirements("ubuntu", "20.04"))')
-
-
-      - name: Install dependencies
-        run: |
-          remotes::install_deps(dependencies = TRUE)
-          remotes::install_cran("rcmdcheck")
-        shell: Rscript {0}
-
-      - name: Check
-        id: rcmd_check
-        env:
-          _R_CHECK_CRAN_INCOMING_REMOTE_: false
-        run: rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran", "--force-multiarch"), error_on = "warning", check_dir = "check")
-        shell: Rscript {0}
-
-      - name: Upload check results
-        if: failure()
-        uses: actions/upload-artifact@main
+      - uses: r-lib/actions/setup-r@v1
         with:
-          name: ${{ runner.os }}-r${{ matrix.config.r }}-rust${{ matrix.config.rust-version }}-results
-          path: check
+          r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v1
+        with:
+          extra-packages: rcmdcheck
+
+      - uses: r-lib/actions/check-r-package@v1

--- a/inst/templates/Makevars.win
+++ b/inst/templates/Makevars.win
@@ -3,7 +3,7 @@ TOOLCHAIN = stable-msvc
 TARGET_DIR = ./rust/target
 LIBDIR = $(TARGET_DIR)/$(TARGET)/release
 STATLIB = $(LIBDIR)/lib{{{pkg_name}}}.a
-PKG_LIBS = -L$(LIBDIR) -l{{{pkg_name}}} -lws2_32 -ladvapi32 -luserenv
+PKG_LIBS = -L$(LIBDIR) -l{{{pkg_name}}} -lws2_32 -ladvapi32 -luserenv -lbcrypt
 
 all: C_clean
 

--- a/tests/data/test-knitr-engine-source-01.Rmd
+++ b/tests/data/test-knitr-engine-source-01.Rmd
@@ -10,6 +10,7 @@ knitr::opts_chunk$set(
 Basic use example:
 
 ```{r}
+# foo
 library(rextendr)
 
 # create a Rust function

--- a/tests/data/test-knitr-engine-source-01.Rmd
+++ b/tests/data/test-knitr-engine-source-01.Rmd
@@ -10,7 +10,6 @@ knitr::opts_chunk$set(
 Basic use example:
 
 ```{r}
-# foo
 library(rextendr)
 
 # create a Rust function

--- a/tests/testthat/_snaps/use_extendr.md
+++ b/tests/testthat/_snaps/use_extendr.md
@@ -62,7 +62,7 @@
       TARGET_DIR = ./rust/target
       LIBDIR = $(TARGET_DIR)/$(TARGET)/release
       STATLIB = $(LIBDIR)/libtestpkg.a
-      PKG_LIBS = -L$(LIBDIR) -ltestpkg -lws2_32 -ladvapi32 -luserenv
+      PKG_LIBS = -L$(LIBDIR) -ltestpkg -lws2_32 -ladvapi32 -luserenv -lbcrypt
       
       all: C_clean
       


### PR DESCRIPTION
Close https://github.com/extendr/extendr/issues/339

As of v1.57.0, Rust requires bcrypt to use `BCryptGenRandom` (Before then, it used to work without bcrypt to support Windows XP).

c.f. https://github.com/rust-lang/rust/pull/84096