### PR TITLE
Use Bootstrap 5 template on pkgdown website

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,3 +1,6 @@
+template:
+  bootstrap: 5
+
 destination: docs
 
 reference:


### PR DESCRIPTION
pkgdown 2.0.0 has new Bootstrap 5 template. I think it's nice in that it's lighter than the current one.

c.f. https://www.tidyverse.org/blog/2021/12/pkgdown-2-0-0/