### PR TITLE
Add ~/.cargo/bin to PATH manually

### DIFF
--- a/R/source.R
+++ b/R/source.R
@@ -278,7 +278,7 @@ invoke_cargo <- function(toolchain, specific_target, dir, profile,
 
   # If there's no `cargo` found, show some helpful messages.
   no_cargo_found <- isTRUE(nchar(Sys.which("cargo")) == 0)
-  if (no_cargo_found) {
+  if (no_cargo_found && !isTRUE(quiet)) {
     ui_w("Can't find {.code cargo} on the PATH. Please review your Rust installation and PATH setups.")
   }
 
@@ -289,8 +289,8 @@ invoke_cargo <- function(toolchain, specific_target, dir, profile,
     # Whether or not `cargo` is found on the PATH, we append `~/.cargo/bin` because
     # it's possible that `rustc` is not found while `cargo` is (c.f. https://github.com/extendr/rextendr/pull/166#discussion_r775803072).
     # So, we use `no_cargo_found` as a condition only for the friendly message.
-    if (no_cargo_found) {
-      ui_i("For now, {.pkg rextendr} will include {.file ${{HOME}}/.cargo/bin} in PATH temporarily. Please consider adding it in {.file ~/.Renviron}.")
+    if (no_cargo_found && !isTRUE(quiet)) {
+      ui_i("{.pkg rextendr} will temporarily include {.file ${{HOME}}/.cargo/bin} in PATH. Please consider adding it to {.file ~/.Renviron}.")
     }
 
     # In some environments, ~/.cargo/bin might not be included in PATH, so we need

--- a/R/source.R
+++ b/R/source.R
@@ -280,9 +280,9 @@ invoke_cargo <- function(toolchain, specific_target, dir, profile,
     # On Windows, PATH to Rust toolchain should be set by the installer
     processx_env <- NULL
   } else {
-    # On Unix-alike, ~/.cargo/bin might not be included in PATH, so we need to
-    # add it here to make sure. It's added to the tail as a fallback, which is
-    # used only when cargo is not found in the user's PATH
+    # In some environments, ~/.cargo/bin might not be included in PATH, so we need
+    # to set it here to ensure cargo can be invoked. It's added to the tail as a
+    # fallback, which is used only when cargo is not found in the user's PATH.
     path_envvar <- Sys.getenv("PATH", unset = "")
     cargo_path <- path.expand("~/.cargo/bin")
     # "current" means appending or overwriting the envvars in addition to the current ones.

--- a/R/source.R
+++ b/R/source.R
@@ -280,11 +280,13 @@ invoke_cargo <- function(toolchain, specific_target, dir, profile,
     # On Windows, PATH to Rust toolchain should be set by the installer
     processx_env <- NULL
   } else {
-  	# On Unix-alike, ~/.cargo/bin is not included in PATH, so we need to set it here to make sure
+    # On Unix-alike, ~/.cargo/bin might not be included in PATH, so we need to
+    # add it here to make sure. It's added to the tail as a fallback, which is
+    # used only when cargo is not found in the user's PATH
     path_envvar <- Sys.getenv("PATH", unset = "")
     cargo_path <- path.expand("~/.cargo/bin")
     # "current" means appending or overwriting the envvars in addition to the current ones.
-    processx_env <- c("current", PATH = glue("{cargo_path}:{path_envvar}"))
+    processx_env <- c("current", PATH = glue("{path_envvar}:{cargo_path}"))
   }
 
   compilation_result <- processx::run(

--- a/R/source.R
+++ b/R/source.R
@@ -283,7 +283,8 @@ invoke_cargo <- function(toolchain, specific_target, dir, profile,
   	# On Unix-alike, ~/.cargo/bin is not included in PATH, so we need to set it here to make sure
     path_envvar <- Sys.getenv("PATH", unset = "")
     cargo_path <- path.expand("~/.cargo/bin")
-    processx_env <- c(PATH = glue("{cargo_path}:{path_envvar}"))
+    # "current" means appending or overwriting the envvars in addition to the current ones.
+    processx_env <- c("current", PATH = glue("{cargo_path}:{path_envvar}"))
   }
 
   compilation_result <- processx::run(

--- a/R/source.R
+++ b/R/source.R
@@ -278,7 +278,7 @@ invoke_cargo <- function(toolchain, specific_target, dir, profile,
 
   if (identical(.Platform$OS.type, "windows")) {
     # On Windows, PATH to Rust toolchain should be set by the installer
-    processx_env <- NULL
+    cargo_envvars <- NULL
   } else {
     # In some environments, ~/.cargo/bin might not be included in PATH, so we need
     # to set it here to ensure cargo can be invoked. It's added to the tail as a
@@ -286,7 +286,7 @@ invoke_cargo <- function(toolchain, specific_target, dir, profile,
     path_envvar <- Sys.getenv("PATH", unset = "")
     cargo_path <- path.expand("~/.cargo/bin")
     # "current" means appending or overwriting the envvars in addition to the current ones.
-    processx_env <- c("current", PATH = glue("{path_envvar}:{cargo_path}"))
+    cargo_envvars <- c("current", PATH = glue("{path_envvar}:{cargo_path}"))
   }
 
   compilation_result <- processx::run(
@@ -314,7 +314,7 @@ invoke_cargo <- function(toolchain, specific_target, dir, profile,
     stdout_line_callback = function(line, ...) {
       assign("message_buffer", c(message_buffer, line), envir = env)
     },
-    env = processx_env
+    env = cargo_envvars
   )
 
   check_cargo_output(compilation_result, message_buffer, tty_has_colors, quiet)

--- a/R/source.R
+++ b/R/source.R
@@ -276,23 +276,10 @@ invoke_cargo <- function(toolchain, specific_target, dir, profile,
 
   tty_has_colors <- isTRUE(cli::num_ansi_colors() > 1L)
 
-  # If there's no `cargo` found, show some helpful messages.
-  no_cargo_found <- isTRUE(nchar(Sys.which("cargo")) == 0)
-  if (no_cargo_found && !isTRUE(quiet)) {
-    ui_w("Can't find {.code cargo} on the PATH. Please review your Rust installation and PATH setups.")
-  }
-
   if (identical(.Platform$OS.type, "windows")) {
     # On Windows, PATH to Rust toolchain should be set by the installer
     cargo_envvars <- NULL
   } else {
-    # Whether or not `cargo` is found on the PATH, we append `~/.cargo/bin` because
-    # it's possible that `rustc` is not found while `cargo` is (c.f. https://github.com/extendr/rextendr/pull/166#discussion_r775803072).
-    # So, we use `no_cargo_found` as a condition only for the friendly message.
-    if (no_cargo_found && !isTRUE(quiet)) {
-      ui_i("{.pkg rextendr} will temporarily include {.file ${{HOME}}/.cargo/bin} in PATH. Please consider adding it to {.file ~/.Renviron}.")
-    }
-
     # In some environments, ~/.cargo/bin might not be included in PATH, so we need
     # to set it here to ensure cargo can be invoked. It's added to the tail as a
     # fallback, which is used only when cargo is not found in the user's PATH.

--- a/R/source.R
+++ b/R/source.R
@@ -276,10 +276,23 @@ invoke_cargo <- function(toolchain, specific_target, dir, profile,
 
   tty_has_colors <- isTRUE(cli::num_ansi_colors() > 1L)
 
+  # If there's no `cargo` found, show some helpful messages.
+  no_cargo_found <- isTRUE(nchar(Sys.which("cargo")) == 0)
+  if (no_cargo_found) {
+    ui_w("Can't find {.code cargo} on the PATH. Please review your Rust installation and PATH setups.")
+  }
+
   if (identical(.Platform$OS.type, "windows")) {
     # On Windows, PATH to Rust toolchain should be set by the installer
     cargo_envvars <- NULL
   } else {
+    # Whether or not `cargo` is found on the PATH, we append `~/.cargo/bin` because
+    # it's possible that `rustc` is not found while `cargo` is (c.f. https://github.com/extendr/rextendr/pull/166#discussion_r775803072).
+    # So, we use `no_cargo_found` as a condition only for the friendly message.
+    if (no_cargo_found) {
+      ui_i("For now, {.pkg rextendr} will include {.file ${{HOME}}/.cargo/bin} in PATH temporarily. Please consider adding it in {.file ~/.Renviron}.")
+    }
+
     # In some environments, ~/.cargo/bin might not be included in PATH, so we need
     # to set it here to ensure cargo can be invoked. It's added to the tail as a
     # fallback, which is used only when cargo is not found in the user's PATH.

--- a/R/use_extendr.R
+++ b/R/use_extendr.R
@@ -136,11 +136,12 @@ use_rextendr_template <- function(template, save_as = template, data = list(), q
   template_content <- glue::glue_data(
     template_content,
     .x = data,
-    .open = "{{{", .close = "}}}"
+    .open = "{{{", .close = "}}}",
+    .trim = FALSE
   )
 
   write_file(
-    template_content,
+    stringi::stri_trim(template_content),
     path = save_as,
     search_root_from = rprojroot::find_package_root_file(),
     quiet = quiet

--- a/inst/templates/Makevars
+++ b/inst/templates/Makevars
@@ -8,8 +8,10 @@ all: C_clean
 $(SHLIB): $(STATLIB)
 
 $(STATLIB):
-	# In some environment, ~/.cargo/bin is not included in PATH, so we need to set it here to make sure
-	export PATH="$(HOME)/.cargo/bin:$(PATH)" && \
+	# In some environments, ~/.cargo/bin might not be included in PATH, so we need
+	# to set it here to ensure cargo can be invoked. It's added to the tail as a
+	# fallback, which is used only when cargo is not found in the user's PATH.
+	export PATH="$(PATH):$(HOME)/.cargo/bin" && \
 		cargo build --lib --release --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
 
 C_clean:

--- a/inst/templates/Makevars
+++ b/inst/templates/Makevars
@@ -9,7 +9,8 @@ $(SHLIB): $(STATLIB)
 
 $(STATLIB):
 	# In some environment, ~/.cargo/bin is not included in PATH, so we need to set it here to make sure
-	PATH="$(HOME)/.cargo/bin:$(PATH)" cargo build --lib --release --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
+	export PATH="$(HOME)/.cargo/bin:$(PATH)" && \
+		cargo build --lib --release --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
 
 C_clean:
 	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS)

--- a/inst/templates/Makevars
+++ b/inst/templates/Makevars
@@ -9,8 +9,8 @@ $(SHLIB): $(STATLIB)
 
 $(STATLIB):
 	# In some environments, ~/.cargo/bin might not be included in PATH, so we need
-	# to set it here to ensure cargo can be invoked. It's added to the tail as a
-	# fallback, which is used only when cargo is not found in the user's PATH.
+	# to set it here to ensure cargo can be invoked. It is appended to PATH and
+	# therefore is only used if cargo is absent from the user's PATH.
 	export PATH="$(PATH):$(HOME)/.cargo/bin" && \
 		cargo build --lib --release --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
 

--- a/inst/templates/Makevars
+++ b/inst/templates/Makevars
@@ -8,7 +8,8 @@ all: C_clean
 $(SHLIB): $(STATLIB)
 
 $(STATLIB):
-	cargo build --lib --release --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
+	# In some environment, ~/.cargo/bin is not included in PATH, so we need to set it here to make sure
+	PATH="$(HOME)/.cargo/bin:$(PATH)" cargo build --lib --release --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
 
 C_clean:
 	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS)

--- a/tests/testthat/_snaps/use_extendr.md
+++ b/tests/testthat/_snaps/use_extendr.md
@@ -44,7 +44,8 @@
       $(SHLIB): $(STATLIB)
       
       $(STATLIB):
-      	cargo build --lib --release --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
+      	# In some environment, ~/.cargo/bin is not included in PATH, so we need to set it here to make sure
+      	PATH="$(HOME)/.cargo/bin:$(PATH)" cargo build --lib --release --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
       
       C_clean:
       	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS)

--- a/tests/testthat/_snaps/use_extendr.md
+++ b/tests/testthat/_snaps/use_extendr.md
@@ -45,8 +45,8 @@
       
       $(STATLIB):
       	# In some environments, ~/.cargo/bin might not be included in PATH, so we need
-      	# to set it here to ensure cargo can be invoked. It's added to the tail as a
-      	# fallback, which is used only when cargo is not found in the user's PATH.
+      	# to set it here to ensure cargo can be invoked. It is appended to PATH and
+      	# therefore is only used if cargo is absent from the user's PATH.
       	export PATH="$(PATH):$(HOME)/.cargo/bin" && \
       		cargo build --lib --release --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
       

--- a/tests/testthat/_snaps/use_extendr.md
+++ b/tests/testthat/_snaps/use_extendr.md
@@ -45,7 +45,8 @@
       
       $(STATLIB):
       	# In some environment, ~/.cargo/bin is not included in PATH, so we need to set it here to make sure
-      	PATH="$(HOME)/.cargo/bin:$(PATH)" cargo build --lib --release --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
+      	export PATH="$(HOME)/.cargo/bin:$(PATH)" && \
+      		cargo build --lib --release --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
       
       C_clean:
       	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS)

--- a/tests/testthat/_snaps/use_extendr.md
+++ b/tests/testthat/_snaps/use_extendr.md
@@ -44,8 +44,10 @@
       $(SHLIB): $(STATLIB)
       
       $(STATLIB):
-      	# In some environment, ~/.cargo/bin is not included in PATH, so we need to set it here to make sure
-      	export PATH="$(HOME)/.cargo/bin:$(PATH)" && \
+      	# In some environments, ~/.cargo/bin might not be included in PATH, so we need
+      	# to set it here to ensure cargo can be invoked. It's added to the tail as a
+      	# fallback, which is used only when cargo is not found in the user's PATH.
+      	export PATH="$(PATH):$(HOME)/.cargo/bin" && \
       		cargo build --lib --release --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
       
       C_clean:

--- a/tests/testthat/test-source.R
+++ b/tests/testthat/test-source.R
@@ -58,7 +58,9 @@ test_that("`options` override `rextendr.extendr_deps` value in `rust_source`", {
 })
 
 test_that("`rust_source` works even when the PATH is not set correctly", {
-  skip_on_os("windows")
+  skip_on_os("windows")  # On Windows, we have no concern as the only installation method is the official installer
+  skip_on_os("linux")    # On Linux, `cargo` might be on somewhere like `/usr/bin`, which is hard to eliminate
+  skip_on_cran()
 
   # Construct PATH without ~/.cargo/bin
   local_path <- Sys.getenv("PATH")

--- a/tests/testthat/test-source.R
+++ b/tests/testthat/test-source.R
@@ -63,7 +63,7 @@ test_that("`rust_source` works even when the PATH is not set correctly", {
   # Construct PATH without ~/.cargo/bin
   local_path <- Sys.getenv("PATH")
   local_path <- stringi::stri_split_fixed(local_path, ":")[[1]]
-  local_path <- stringi::stri_subset_fixed(local_path, ".cargo/bin")
+  local_path <- stringi::stri_subset_fixed(local_path, ".cargo/bin", negate = TRUE)
   local_path <- glue_collapse(local_path, sep = ":")
 
   withr::local_envvar(PATH = local_path)

--- a/tests/testthat/test-source.R
+++ b/tests/testthat/test-source.R
@@ -57,7 +57,7 @@ test_that("`options` override `rextendr.extendr_deps` value in `rust_source`", {
   expect_rextendr_error(rust_function("fn rust_test() {}"), "Rust code could not be compiled successfully. Aborting.")
 })
 
-test_that("`rust_source` works even when the PATH is not set correctly", {
+test_that("`rust_source` works even when the PATH is not set correctly, which mainly happens on macOS", {
   skip_on_os("windows")  # On Windows, we have no concern as the only installation method is the official installer
   skip_on_os("linux")    # On Linux, `cargo` might be on somewhere like `/usr/bin`, which is hard to eliminate
   skip_on_cran()


### PR DESCRIPTION
Address https://github.com/extendr/rextendr/pull/155#issuecomment-1000565432, fix https://github.com/extendr/rextendr/issues/99

It seems we at last find how to set `PATH` reliably, but, as I commented on #155, there are some CRAN machines that doesn't have `~/.cargo/bin` included (I forgot which, but probably it was macOS). This means, if a package developer aims to release their package on CRAN, they needs to tweak `PATH` anyway. So, while this isn't very cool, it's safe to include `~/.cargo/bin` in `PATH` every time when rextendr invokes `cargo` command.

~~Currently, a test fails if `Makevars` contains `\`-terminated lines. I need to figure out how to fix it~~ (edit: fixed now), but this pull request is basically ready for review.