### PR TITLE
Remove an unused dependency {pkgload}

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -48,7 +48,6 @@ Imports:
     glue,
     jsonlite,
     pkgbuild,
-    pkgload,
     processx,
     purrr,
     rlang (>= 0.4.10),


### PR DESCRIPTION
I see this NOTE. It seems https://github.com/extendr/rextendr/pull/67 removed the need for `pkgload::load_all()`. So, pkgload is not used currently and should be safe to remove.

```
* checking dependencies in R code ... NOTE
Namespace in Imports field not imported from: 'pkgload'
  All declared Imports should be used.
```