### PR TITLE
[PoC] Support R-devel

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -45,11 +45,11 @@ jobs:
 
       # Rtools40 contains the GCC10 toolchains in /ucrt64 directory
       - name: Use ucrt64
-        if: startsWith(runner.os, 'Windows') && ${{ matrix.config.r }} == 'devel'
+        if: startsWith(runner.os, 'Windows') && '${{ matrix.config.r }}' == 'devel'
         run: |
           # debug
           echo "${env:RTOOLS40_HOME}"
-          ls -d "${env:RTOOLS40_HOME}/ucrt64"
+          ls "${env:RTOOLS40_HOME}\ucrt64"
           # edd to PATH
           echo "${env:RTOOLS40_HOME}\ucrt64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           # confirm

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -45,15 +45,15 @@ jobs:
 
       # Rtools40 contains the GCC10 toolchains in /ucrt64 directory
       - name: Use ucrt64
-        if: startsWith(runner.os, 'Windows') && '${{ matrix.config.r }}' == 'devel'
+        if: startsWith(runner.os, 'Windows') && matrix.config.r == 'devel'
         run: |
           # debug
           echo "${env:RTOOLS40_HOME}"
-          ls "${env:RTOOLS40_HOME}\ucrt64"
+          Get-ChildItem "${env:RTOOLS40_HOME}/ucrt64"
           # edd to PATH
           echo "${env:RTOOLS40_HOME}\ucrt64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           # confirm
-          rm -rf "${env:RTOOLS40_HOME}\mingw64" "${env:RTOOLS40_HOME}\mingw32"
+          Remove-Item -Recurse -Force "${env:RTOOLS40_HOME}\mingw64" "${env:RTOOLS40_HOME}\mingw32"
         shell: pwsh
 
       - uses: r-lib/actions/setup-r@v1

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -38,7 +38,7 @@ jobs:
           default: true
 
       - name: Configure Windows
-        if: startsWith(runner.os, 'Windows') && matrix.config.r == 'release'
+        if: startsWith(runner.os, 'Windows') && matrix.config.r != 'devel'
         run: |
           rustup target add x86_64-pc-windows-gnu
           rustup target add i686-pc-windows-gnu

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -38,21 +38,17 @@ jobs:
           default: true
 
       - name: Configure Windows
-        if: startsWith(runner.os, 'Windows')
+        if: startsWith(runner.os, 'Windows') && matrix.config.r == 'release'
         run: |
           rustup target add x86_64-pc-windows-gnu
           rustup target add i686-pc-windows-gnu
 
-      # Rtools40 contains the GCC10 toolchains in /ucrt64 directory
-      - name: Use ucrt64
+      - name: Configure Windows (UCRT)
         if: startsWith(runner.os, 'Windows') && matrix.config.r == 'devel'
         run: |
-          # debug
-          echo "${env:RTOOLS40_HOME}"
-          Get-ChildItem "${env:RTOOLS40_HOME}/ucrt64"
-          # edd to PATH
+          rustup target add x86_64-pc-windows-gnu
           echo "${env:RTOOLS40_HOME}\ucrt64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-          # confirm
+          # To confirm the tests work without the legacy toolchains, remove them
           Remove-Item -Recurse -Force "${env:RTOOLS40_HOME}\mingw64"
           Remove-Item -Recurse -Force "${env:RTOOLS40_HOME}\mingw32"
         shell: pwsh

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -17,6 +17,7 @@ jobs:
       matrix:
         config:
           - {os: windows-latest, r: 'release', rust-version: 'stable-msvc'}
+          - {os: windows-latest, r: 'devel',   rust-version: 'stable-msvc'}
           - {os: macOS-latest,   r: 'release', rust-version: 'stable'     }
           - {os: ubuntu-20.04,   r: 'release', rust-version: 'stable'     }
           - {os: ubuntu-20.04,   r: 'devel',   rust-version: 'stable'     }
@@ -41,6 +42,19 @@ jobs:
         run: |
           rustup target add x86_64-pc-windows-gnu
           rustup target add i686-pc-windows-gnu
+
+      # Rtools40 contains the GCC10 toolchains in /ucrt64 directory
+      - name: Use ucrt64
+        if: startsWith(runner.os, 'Windows') && ${{ matrix.config.r }} == 'devel'
+        run: |
+          # debug
+          echo "${env:RTOOLS40_HOME}"
+          ls -d "${env:RTOOLS40_HOME}/ucrt64"
+          # edd to PATH
+          echo "${env:RTOOLS40_HOME}\ucrt64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          # confirm
+          rm -rf "${env:RTOOLS40_HOME}\mingw64" "${env:RTOOLS40_HOME}\mingw32"
+        shell: pwsh
 
       - uses: r-lib/actions/setup-r@v1
         with:

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,6 +1,6 @@
 on:
   push:
-    branches: [main, master, ci/*]
+    branches: [main, master]
   pull_request:
     branches: [main, master]
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,6 +1,6 @@
 on:
   push:
-    branches: [main, master]
+    branches: [main, master, ci/*]
   pull_request:
     branches: [main, master]
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -53,7 +53,8 @@ jobs:
           # edd to PATH
           echo "${env:RTOOLS40_HOME}\ucrt64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           # confirm
-          Remove-Item -Recurse -Force "${env:RTOOLS40_HOME}\mingw64" "${env:RTOOLS40_HOME}\mingw32"
+          Remove-Item -Recurse -Force "${env:RTOOLS40_HOME}\mingw64"
+          Remove-Item -Recurse -Force "${env:RTOOLS40_HOME}\mingw32"
         shell: pwsh
 
       - uses: r-lib/actions/setup-r@v1

--- a/.github/workflows/test_pkg_gen.yaml
+++ b/.github/workflows/test_pkg_gen.yaml
@@ -78,6 +78,9 @@ jobs:
         run: |
           rustup target add x86_64-pc-windows-gnu
           echo "${env:RTOOLS40_HOME}\ucrt64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          # To confirm the tests work without the legacy toolchains, remove them
+          Remove-Item -Recurse -Force "${env:RTOOLS40_HOME}\mingw64"
+          Remove-Item -Recurse -Force "${env:RTOOLS40_HOME}\mingw32"
         shell: pwsh
 
       - name: Configure Linux

--- a/.github/workflows/test_pkg_gen.yaml
+++ b/.github/workflows/test_pkg_gen.yaml
@@ -64,7 +64,7 @@ jobs:
           restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
 
       - name: Configure Windows
-        if: startsWith(runner.os, 'Windows') && matrix.config.r == 'release'
+        if: startsWith(runner.os, 'Windows') && matrix.config.r != 'devel'
         run: |
           rustup target add x86_64-pc-windows-gnu
           rustup target add i686-pc-windows-gnu

--- a/.github/workflows/test_pkg_gen.yaml
+++ b/.github/workflows/test_pkg_gen.yaml
@@ -3,7 +3,6 @@ on:
     branches:
       - main
       - master
-      - ci/*
   pull_request:
     branches:
       - main

--- a/.github/workflows/test_pkg_gen.yaml
+++ b/.github/workflows/test_pkg_gen.yaml
@@ -3,6 +3,7 @@ on:
     branches:
       - main
       - master
+      - ci/*
   pull_request:
     branches:
       - main
@@ -20,10 +21,11 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: windows-latest, r: 'release', rust-version: 'stable-msvc'}
-          - {os: macOS-latest, r: 'release', rust-version: 'stable'}
-          - {os: ubuntu-20.04, r: 'release', rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
-          - {os: ubuntu-20.04, r: 'devel', rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
+          - {os: windows-latest, r: 'release',  rust-version: 'stable-msvc'}
+          - {os: windows-latest, r: 'devel',    rust-version: 'stable-msvc'}
+          - {os: macOS-latest,   r: 'release',  rust-version: 'stable'}
+          - {os: ubuntu-20.04,   r: 'release',  rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
+          - {os: ubuntu-20.04,   r: 'devel',    rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
@@ -63,12 +65,19 @@ jobs:
           restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
 
       - name: Configure Windows
-        if: startsWith(runner.os, 'Windows')
+        if: startsWith(runner.os, 'Windows') && matrix.config.r == 'release'
         run: |
           rustup target add x86_64-pc-windows-gnu
           rustup target add i686-pc-windows-gnu
           echo "C:\msys64\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           echo "C:\msys64\mingw32\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        shell: pwsh
+
+      - name: Configure Windows (UCRT)
+        if: startsWith(runner.os, 'Windows') && matrix.config.r == 'devel'
+        run: |
+          rustup target add x86_64-pc-windows-gnu
+          echo "${env:RTOOLS40_HOME}\ucrt64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
         shell: pwsh
 
       - name: Configure Linux


### PR DESCRIPTION
(Do not merge this, things are changing fast...)

Eventually fixes #162

It turned out Rtools42 is not used yet (ref: https://community.rstudio.com/t/what-is-or-can-be-the-plan-to-support-rtools42-on-r-lib-actions/125114/4) while the R-devel's source code already expects it. Are you wondering like "then, why does this work"? The reason is that Rtools40 also contains the toolchain with the same compiler as Rtools42 under `${RTOOLS40_HOME}/ucrt64`. This pull request tries to handle it.