### PR TITLE
Use rtools42

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -37,6 +37,12 @@ jobs:
           toolchain: ${{ matrix.config.rust-version }}
           default: true
 
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: ${{ matrix.config.r }}
+          rtools-version: ${{ matrix.config.rtools-version }}
+          use-public-rspm: true
+
       - name: Configure Windows
         if: startsWith(runner.os, 'Windows') && matrix.config.r != 'devel'
         run: |
@@ -64,12 +70,6 @@ jobs:
           cp `
             "${rtools42_home}\x86_64-w64-mingw32.static.posix\lib\gcc\x86_64-w64-mingw32.static.posix\10.3.0\libgcc.a" `
             "${rtools42_home}\x86_64-w64-mingw32.static.posix\lib\gcc\x86_64-w64-mingw32.static.posix\10.3.0\libgcc_s.a"
-
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          r-version: ${{ matrix.config.r }}
-          rtools-version: ${{ matrix.config.rtools-version }}
-          use-public-rspm: true
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -59,18 +59,6 @@ jobs:
           Remove-Item -Recurse -Force "${env:RTOOLS40_HOME}\mingw32"
           Remove-Item -Recurse -Force "${env:RTOOLS40_HOME}\ucrt64"
 
-          $rtools42_home = "C:\rtools42"
-
-          # rustc adds -lgcc_eh and -lgcc_s flag to the compiler, but there's no libgcc_eh or libgcc_a in Rtools42.
-          # For more details, please refer to https://github.com/r-windows/rtools-packages/blob/2407b23f1e0925bbb20a4162c963600105236318/mingw-w64-gcc/PKGBUILD#L313-L316
-          cp `
-            "${rtools42_home}\x86_64-w64-mingw32.static.posix\lib\gcc\x86_64-w64-mingw32.static.posix\10.3.0\libgcc.a" `
-            "${rtools42_home}\x86_64-w64-mingw32.static.posix\lib\gcc\x86_64-w64-mingw32.static.posix\10.3.0\libgcc_eh.a"
-
-          cp `
-            "${rtools42_home}\x86_64-w64-mingw32.static.posix\lib\gcc\x86_64-w64-mingw32.static.posix\10.3.0\libgcc.a" `
-            "${rtools42_home}\x86_64-w64-mingw32.static.posix\lib\gcc\x86_64-w64-mingw32.static.posix\10.3.0\libgcc_s.a"
-
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           cache-version: 2

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -46,7 +46,8 @@ jobs:
         with:
           r-version: ${{ matrix.config.r }}
           rtools-version: ${{ matrix.config.rtools-version }}
-          use-public-rspm: true
+          # TODO: enable RSPM when all the packages are available
+          use-public-rspm: false
 
       - name: Configure Windows (R >= 4.2)
         if: startsWith(runner.os, 'Windows') && matrix.config.r != '4.1'

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -16,9 +16,14 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: windows-latest, r: 'release', rust-version: 'stable-msvc'}
+          - {os: windows-latest, r: 'release', rust-version: 'stable-gnu',  rtools-version: '42'}
           - {os: windows-latest, r: 'devel',   rust-version: 'stable-gnu',  rtools-version: '42'}
+          # For R < 4.2, the MSVC toolchain is used to support cross-compilation for the 32-bit.
+          # TODO: Remove this runner when we drop the support for R < 4.2
+          - {os: windows-latest, r: '4.1',     rust-version: 'stable-msvc'}
+
           - {os: macOS-latest,   r: 'release', rust-version: 'stable'     }
+
           - {os: ubuntu-20.04,   r: 'release', rust-version: 'stable'     }
           - {os: ubuntu-20.04,   r: 'devel',   rust-version: 'stable'     }
 
@@ -43,14 +48,8 @@ jobs:
           rtools-version: ${{ matrix.config.rtools-version }}
           use-public-rspm: true
 
-      - name: Configure Windows
-        if: startsWith(runner.os, 'Windows') && matrix.config.r != 'devel'
-        run: |
-          rustup target add x86_64-pc-windows-gnu
-          rustup target add i686-pc-windows-gnu
-
-      - name: Configure Windows (R-devel)
-        if: startsWith(runner.os, 'Windows') && matrix.config.r == 'devel'
+      - name: Configure Windows (R >= 4.2)
+        if: startsWith(runner.os, 'Windows') && matrix.config.r != '4.1'
         run: |
           rustup target add x86_64-pc-windows-gnu
 
@@ -58,6 +57,14 @@ jobs:
           Remove-Item -Recurse -Force "${env:RTOOLS40_HOME}\mingw64"
           Remove-Item -Recurse -Force "${env:RTOOLS40_HOME}\mingw32"
           Remove-Item -Recurse -Force "${env:RTOOLS40_HOME}\ucrt64"
+
+
+      # TODO: Remove this runner when we drop the support for R < 4.2
+      - name: Configure Windows (R < 4.2)
+        if: startsWith(runner.os, 'Windows') && matrix.config.r == '4.1'
+        run: |
+          rustup target add x86_64-pc-windows-gnu
+          rustup target add i686-pc-windows-gnu
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -17,6 +17,7 @@ jobs:
       matrix:
         config:
           - {os: windows-latest, r: 'release', rust-version: 'stable-msvc'}
+          - {os: windows-latest, r: 'devel',   rust-version: 'stable-gnu',  rtools-version: '42'}
           - {os: macOS-latest,   r: 'release', rust-version: 'stable'     }
           - {os: ubuntu-20.04,   r: 'release', rust-version: 'stable'     }
           - {os: ubuntu-20.04,   r: 'devel',   rust-version: 'stable'     }
@@ -37,15 +38,25 @@ jobs:
           default: true
 
       - name: Configure Windows
-        if: startsWith(runner.os, 'Windows')
+        if: startsWith(runner.os, 'Windows') && matrix.config.r != 'devel'
         run: |
           rustup target add x86_64-pc-windows-gnu
           rustup target add i686-pc-windows-gnu
 
+      - name: Configure Windows (R-devel)
+        if: startsWith(runner.os, 'Windows') && matrix.config.r == 'devel'
+        run: |
+          rustup target add x86_64-pc-windows-gnu
+
+          # To confirm the tests work without the legacy toolchains, remove them
+          Remove-Item -Recurse -Force "${env:RTOOLS40_HOME}\mingw64"
+          Remove-Item -Recurse -Force "${env:RTOOLS40_HOME}\mingw32"
+          Remove-Item -Recurse -Force "${env:RTOOLS40_HOME}\ucrt64"
+
       - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
-          http-user-agent: ${{ matrix.config.http-user-agent }}
+          rtools-version: ${{ matrix.config.rtools-version }}
           use-public-rspm: true
 
       - uses: r-lib/actions/setup-r-dependencies@v2

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -53,6 +53,18 @@ jobs:
           Remove-Item -Recurse -Force "${env:RTOOLS40_HOME}\mingw32"
           Remove-Item -Recurse -Force "${env:RTOOLS40_HOME}\ucrt64"
 
+          $rtools42_home = "C:\rtools42"
+
+          # rustc adds -lgcc_eh and -lgcc_s flag to the compiler, but there's no libgcc_eh or libgcc_a in Rtools42.
+          # For more details, please refer to https://github.com/r-windows/rtools-packages/blob/2407b23f1e0925bbb20a4162c963600105236318/mingw-w64-gcc/PKGBUILD#L313-L316
+          cp `
+            "${rtools42_home}\x86_64-w64-mingw32.static.posix\lib\gcc\x86_64-w64-mingw32.static.posix\10.3.0\libgcc.a" `
+            "${rtools42_home}\x86_64-w64-mingw32.static.posix\lib\gcc\x86_64-w64-mingw32.static.posix\10.3.0\libgcc_eh.a"
+
+          cp `
+            "${rtools42_home}\x86_64-w64-mingw32.static.posix\lib\gcc\x86_64-w64-mingw32.static.posix\10.3.0\libgcc.a" `
+            "${rtools42_home}\x86_64-w64-mingw32.static.posix\lib\gcc\x86_64-w64-mingw32.static.posix\10.3.0\libgcc_s.a"
+
       - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}

--- a/.github/workflows/test_pkg_gen.yaml
+++ b/.github/workflows/test_pkg_gen.yaml
@@ -20,9 +20,14 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: windows-latest, r: 'release', rust-version: 'stable-msvc'}
+          - {os: windows-latest, r: 'release', rust-version: 'stable-gnu', rtools-version: '42'}
           - {os: windows-latest, r: 'devel',   rust-version: 'stable-gnu', rtools-version: '42'}
+          # For R < 4.2, the MSVC toolchain is used to support cross-compilation for the 32-bit.
+          # TODO: Remove this runner when we drop the support for R < 4.2
+          - {os: windows-latest, r: '4.1',     rust-version: 'stable-msvc'}
+
           - {os: macOS-latest,   r: 'release', rust-version: 'stable'}
+
           - {os: ubuntu-20.04,   r: 'release', rust-version: 'stable'}
           - {os: ubuntu-20.04,   r: 'devel',   rust-version: 'stable'}
 
@@ -55,22 +60,22 @@ jobs:
           cache-version: 2
           extra-packages: rcmdcheck, devtools, usethis
 
-      - name: Configure Windows
-        if: startsWith(runner.os, 'Windows') && matrix.config.r != 'devel'
+      - name: Configure Windows (R >= 4.2)
+        if: startsWith(runner.os, 'Windows') && matrix.config.r != '4.1'
+        run: |
+          rustup target add x86_64-pc-windows-gnu
+          echo "C:\msys64\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        shell: pwsh
+
+      # TODO: Remove this runner when we drop the support for R < 4.2
+      - name: Configure Windows (R < 4.2)
+        if: startsWith(runner.os, 'Windows') && matrix.config.r == '4.1'
         run: |
           rustup target add x86_64-pc-windows-gnu
           rustup target add i686-pc-windows-gnu
           echo "C:\msys64\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           echo "C:\msys64\mingw32\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
         shell: pwsh
-
-      - name: Configure Windows (R-devel)
-        if: startsWith(runner.os, 'Windows') && matrix.config.r == 'devel'
-        run: |
-          rustup target add x86_64-pc-windows-gnu
-          echo "C:\msys64\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-        shell: pwsh
-
 
       - name: Test package generation
         env:

--- a/.github/workflows/test_pkg_gen.yaml
+++ b/.github/workflows/test_pkg_gen.yaml
@@ -69,18 +69,6 @@ jobs:
         run: |
           rustup target add x86_64-pc-windows-gnu
           echo "C:\msys64\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-
-          $rtools42_home = "C:\rtools42"
-
-          # rustc adds -lgcc_eh and -lgcc_s flag to the compiler, but there's no libgcc_eh or libgcc_a in Rtools42.
-          # For more details, please refer to https://github.com/r-windows/rtools-packages/blob/2407b23f1e0925bbb20a4162c963600105236318/mingw-w64-gcc/PKGBUILD#L313-L316
-          cp `
-            "${rtools42_home}\x86_64-w64-mingw32.static.posix\lib\gcc\x86_64-w64-mingw32.static.posix\10.3.0\libgcc.a" `
-            "${rtools42_home}\x86_64-w64-mingw32.static.posix\lib\gcc\x86_64-w64-mingw32.static.posix\10.3.0\libgcc_eh.a"
-
-          cp `
-            "${rtools42_home}\x86_64-w64-mingw32.static.posix\lib\gcc\x86_64-w64-mingw32.static.posix\10.3.0\libgcc.a" `
-            "${rtools42_home}\x86_64-w64-mingw32.static.posix\lib\gcc\x86_64-w64-mingw32.static.posix\10.3.0\libgcc_s.a"
         shell: pwsh
 
 

--- a/.github/workflows/test_pkg_gen.yaml
+++ b/.github/workflows/test_pkg_gen.yaml
@@ -21,9 +21,10 @@ jobs:
       matrix:
         config:
           - {os: windows-latest, r: 'release', rust-version: 'stable-msvc'}
-          - {os: macOS-latest, r: 'release', rust-version: 'stable'}
-          - {os: ubuntu-20.04, r: 'release', rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
-          - {os: ubuntu-20.04, r: 'devel', rust-version: 'stable', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
+          - {os: windows-latest, r: 'devel',   rust-version: 'stable-gnu', rtools-version: '42'}
+          - {os: macOS-latest,   r: 'release', rust-version: 'stable'}
+          - {os: ubuntu-20.04,   r: 'release', rust-version: 'stable'}
+          - {os: ubuntu-20.04,   r: 'devel',   rust-version: 'stable'}
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
@@ -42,7 +43,8 @@ jobs:
         uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
-          windows-path-include-mingw: false
+          rtools-version: ${{ matrix.config.rtools-version }}
+          use-public-rspm: true
 
       - name: Set up pandoc
         uses: r-lib/actions/setup-pandoc@v2
@@ -57,9 +59,11 @@ jobs:
         if: startsWith(runner.os, 'Windows')
         run: |
           rustup target add x86_64-pc-windows-gnu
-          rustup target add i686-pc-windows-gnu
           echo "C:\msys64\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-          echo "C:\msys64\mingw32\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          if ('${{ matrix.config.r }}' -ne 'devel') {
+            rustup target add i686-pc-windows-gnu
+            echo "C:\msys64\mingw32\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          }
         shell: pwsh
 
       - name: Test package generation

--- a/.github/workflows/test_pkg_gen.yaml
+++ b/.github/workflows/test_pkg_gen.yaml
@@ -56,15 +56,33 @@ jobs:
           extra-packages: rcmdcheck, devtools, usethis
 
       - name: Configure Windows
-        if: startsWith(runner.os, 'Windows')
+        if: startsWith(runner.os, 'Windows') && matrix.config.r != 'devel'
+        run: |
+          rustup target add x86_64-pc-windows-gnu
+          rustup target add i686-pc-windows-gnu
+          echo "C:\msys64\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          echo "C:\msys64\mingw32\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        shell: pwsh
+
+      - name: Configure Windows (R-devel)
+        if: startsWith(runner.os, 'Windows') && matrix.config.r == 'devel'
         run: |
           rustup target add x86_64-pc-windows-gnu
           echo "C:\msys64\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-          if ('${{ matrix.config.r }}' -ne 'devel') {
-            rustup target add i686-pc-windows-gnu
-            echo "C:\msys64\mingw32\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-          }
+
+          $rtools42_home = "C:\rtools42"
+
+          # rustc adds -lgcc_eh and -lgcc_s flag to the compiler, but there's no libgcc_eh or libgcc_a in Rtools42.
+          # For more details, please refer to https://github.com/r-windows/rtools-packages/blob/2407b23f1e0925bbb20a4162c963600105236318/mingw-w64-gcc/PKGBUILD#L313-L316
+          cp `
+            "${rtools42_home}\x86_64-w64-mingw32.static.posix\lib\gcc\x86_64-w64-mingw32.static.posix\10.3.0\libgcc.a" `
+            "${rtools42_home}\x86_64-w64-mingw32.static.posix\lib\gcc\x86_64-w64-mingw32.static.posix\10.3.0\libgcc_eh.a"
+
+          cp `
+            "${rtools42_home}\x86_64-w64-mingw32.static.posix\lib\gcc\x86_64-w64-mingw32.static.posix\10.3.0\libgcc.a" `
+            "${rtools42_home}\x86_64-w64-mingw32.static.posix\lib\gcc\x86_64-w64-mingw32.static.posix\10.3.0\libgcc_s.a"
         shell: pwsh
+
 
       - name: Test package generation
         env:

--- a/.github/workflows/test_pkg_gen.yaml
+++ b/.github/workflows/test_pkg_gen.yaml
@@ -49,7 +49,8 @@ jobs:
         with:
           r-version: ${{ matrix.config.r }}
           rtools-version: ${{ matrix.config.rtools-version }}
-          use-public-rspm: true
+          # TODO: enable RSPM when all the packages are available
+          use-public-rspm: false
 
       - name: Set up pandoc
         uses: r-lib/actions/setup-pandoc@v2

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ vignettes/*.pdf
 
 **/.vscode/*
 
+/inst/libgcc_mock

--- a/R/source.R
+++ b/R/source.R
@@ -281,7 +281,18 @@ invoke_cargo <- function(toolchain, specific_target, dir, profile,
     # On Windows, PATH to Rust toolchain should be set by the installer.
     # If R >= 4.2, we need to override the linker setting.
     if (identical(R.version$crt, "ucrt")) {
-      cargo_envvars <- c("current", CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER = "x86_64-w64-mingw32.static.posix-gcc.exe")
+      # libgcc_mock is created in configure.ucrt on installation.
+      libgcc_path <- system.file("libgcc_mock", package = "rextendr")
+      if (identical(libgcc_path, "")) {
+        ui_throw(
+          "Unable to find {.file inst/libgcc_mock}. Please reinstall the rextendr package",
+        )
+      }
+
+      cargo_envvars <- c("current",
+        CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER = "x86_64-w64-mingw32.static.posix-gcc.exe",
+        LIBRARY_PATH = paste0(libgcc_path, ";", Sys.getenv("LIBRARY_PATH"))
+      )
     } else {
       cargo_envvars <- NULL
     }

--- a/R/source.R
+++ b/R/source.R
@@ -251,24 +251,25 @@ invoke_cargo <- function(toolchain, specific_target, dir, profile,
     # rtools_path() returns path to the RTOOLS40_HOME\usr\bin,
     # but we need RTOOLS40_HOME\mingw{arch}\bin, hence the "../.."
     rtools_home <- normalizePath(
-      # `pkgbuild` may return two paths for R < 4.2 if Rtools42 is present
+      # `pkgbuild` may return two paths for R < 4.2 with Rtools40v2
       file.path(pkgbuild::rtools_path()[1], "..", ".."),
       winslash = "/",
       mustWork = TRUE
     )
 
-    rtools_bin_path <-
-      normalizePath(
-        file.path(
-          rtools_home,
-          paste0("mingw", ifelse(R.version$arch == "i386", "32", "64")),
-          "bin"
-        )
-      )
-    # Appends path to rtools\mingw{arch}\bin using a correct arch
+    if (identical(R.version$crt, "ucrt")) {
+      # c.f. https://github.com/wch/r-source/blob/f09d3d7fa4af446ad59a375d914a0daf3ffc4372/src/library/profile/Rprofile.windows#L70-L71
+      subdir <- c("x86_64-w64-mingw32.static.posix", "usr")
+      # If RTOOLS42_HOME is properly set, this will have no real effect
+      withr::local_envvar(RTOOLS42_HOME = rtools_home)
+    } else {
+      subdir <- paste0("mingw", ifelse(R.version$arch == "i386", "32", "64"))
+      # If RTOOLS40_HOME is properly set, this will have no real effect
+      withr::local_envvar(RTOOLS40_HOME = rtools_home)
+    }
+
+    rtools_bin_path <- normalizePath(file.path(rtools_home, subdir, "bin"))
     withr::local_path(rtools_bin_path, action = "suffix")
-    # If RTOOLS40_HOME is properly set, this will have no real effect
-    withr::local_envvar(RTOOLS40_HOME = rtools_home)
   }
 
   message_buffer <- character(0)
@@ -277,8 +278,13 @@ invoke_cargo <- function(toolchain, specific_target, dir, profile,
   tty_has_colors <- isTRUE(cli::num_ansi_colors() > 1L)
 
   if (identical(.Platform$OS.type, "windows")) {
-    # On Windows, PATH to Rust toolchain should be set by the installer
-    cargo_envvars <- NULL
+    # On Windows, PATH to Rust toolchain should be set by the installer.
+    # If R >= 4.2, we need to override the linker setting.
+    if (identical(R.version$crt, "ucrt")) {
+      cargo_envvars <- c("current", CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER = "x86_64-w64-mingw32.static.posix-gcc.exe")
+    } else {
+      cargo_envvars <- NULL
+    }
   } else {
     # In some environments, ~/.cargo/bin might not be included in PATH, so we need
     # to set it here to ensure cargo can be invoked. It's added to the tail as a

--- a/R/use_extendr.R
+++ b/R/use_extendr.R
@@ -87,6 +87,13 @@ use_extendr <- function(path = ".",
   )
 
   use_rextendr_template(
+    "Makevars.ucrt",
+    save_as = file.path("src", "Makevars.ucrt"),
+    quiet = quiet,
+    data = list(lib_name = lib_name)
+  )
+
+  use_rextendr_template(
     "_gitignore",
     save_as = file.path("src", ".gitignore"),
     quiet = quiet

--- a/configure.ucrt
+++ b/configure.ucrt
@@ -1,0 +1,14 @@
+# `rustc` adds `-lgcc_eh` and `-lgcc_s` flags to the compiler, but Rtools' GCC
+# doesn't have `libgcc_eh` or `libgcc_a` due to the compilation settings. So, in
+# order to please the compiler, we need to add empty `libgcc_eh` or `libgcc_a`
+# to the library search paths.
+#
+# For more details, please refer to
+# https://github.com/r-windows/rtools-packages/blob/2407b23f1e0925bbb20a4162c963600105236318/mingw-w64-gcc/PKGBUILD#L313-L316
+
+mkdir -p inst/libgcc_mock
+cd inst/libgcc_mock && \
+	touch gcc_mock.c && \
+	gcc -c gcc_mock.c -o gcc_mock.o && \
+	ar -r libgcc_eh.a gcc_mock.o && \
+	cp libgcc_eh.a libgcc_s.a

--- a/inst/templates/Makevars.ucrt
+++ b/inst/templates/Makevars.ucrt
@@ -1,0 +1,8 @@
+# Use GNU toolchain for R >= 4.2
+TOOLCHAIN = stable-gnu
+
+# Rtools42 doesn't have the linker in the location that cargo expects, so we
+# need to overwrite it via configuration.
+CARGO_LINKER = x86_64-w64-mingw32.static.posix-gcc.exe
+
+include Makevars.win

--- a/inst/templates/Makevars.win
+++ b/inst/templates/Makevars.win
@@ -1,5 +1,8 @@
 TARGET = $(subst 64,x86_64,$(subst 32,i686,$(WIN)))-pc-windows-gnu
-TOOLCHAIN = stable-msvc
+
+# This is provided in Makevars.ucrt for R >= 4.2
+TOOLCHAIN ?= stable-msvc
+
 TARGET_DIR = ./rust/target
 LIBDIR = $(TARGET_DIR)/$(TARGET)/release
 STATLIB = $(LIBDIR)/lib{{{lib_name}}}.a
@@ -10,7 +13,9 @@ all: C_clean
 $(SHLIB): $(STATLIB)
 
 $(STATLIB):
-	cargo +$(TOOLCHAIN) build --target=$(TARGET) --lib --release --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
+	# CARGO_LINKER is provided in Makevars.ucrt for R >= 4.2
+	export CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER="$(CARGO_LINKER)" && \
+	  cargo +$(TOOLCHAIN) build --target=$(TARGET) --lib --release --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
 
 C_clean:
 	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS)

--- a/inst/templates/Makevars.win
+++ b/inst/templates/Makevars.win
@@ -13,9 +13,17 @@ all: C_clean
 $(SHLIB): $(STATLIB)
 
 $(STATLIB):
+	mkdir -p $(TARGET_DIR)/libgcc_mock
+	cd $(TARGET_DIR)/libgcc_mock && \
+		touch gcc_mock.c && \
+		gcc -c gcc_mock.c -o gcc_mock.o && \
+		ar -r libgcc_eh.a gcc_mock.o && \
+		cp libgcc_eh.a libgcc_s.a
+
 	# CARGO_LINKER is provided in Makevars.ucrt for R >= 4.2
 	export CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER="$(CARGO_LINKER)" && \
-	  cargo +$(TOOLCHAIN) build --target=$(TARGET) --lib --release --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
+		export LIBRARY_PATH="$${LIBRARY_PATH};$(CURDIR)/$(TARGET_DIR)/libgcc_mock" && \
+		cargo +$(TOOLCHAIN) build --target=$(TARGET) --lib --release --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
 
 C_clean:
 	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS)

--- a/tests/testthat/_snaps/use_extendr.md
+++ b/tests/testthat/_snaps/use_extendr.md
@@ -33,20 +33,6 @@
 ---
 
     Code
-      cat_file("src", "entrypoint.c")
-    Output
-      // We need to forward routine registration from C to Rust
-      // to avoid the linker removing the static library.
-      
-      void R_init_testpkg_extendr(void *dll);
-      
-      void R_init_testpkg(void *dll) {
-          R_init_testpkg_extendr(dll);
-      }
-
----
-
-    Code
       cat_file("src", "Makevars")
     Output
       TARGET_DIR = ./rust/target
@@ -114,6 +100,20 @@
       CARGO_LINKER = x86_64-w64-mingw32.static.posix-gcc.exe
       
       include Makevars.win
+
+---
+
+    Code
+      cat_file("src", "entrypoint.c")
+    Output
+      // We need to forward routine registration from C to Rust
+      // to avoid the linker removing the static library.
+      
+      void R_init_testpkg_extendr(void *dll);
+      
+      void R_init_testpkg(void *dll) {
+          R_init_testpkg_extendr(dll);
+      }
 
 ---
 

--- a/tests/testthat/_snaps/use_extendr.md
+++ b/tests/testthat/_snaps/use_extendr.md
@@ -77,9 +77,17 @@
       $(SHLIB): $(STATLIB)
       
       $(STATLIB):
+      	mkdir -p $(TARGET_DIR)/libgcc_mock
+      	cd $(TARGET_DIR)/libgcc_mock && \
+      		touch gcc_mock.c && \
+      		gcc -c gcc_mock.c -o gcc_mock.o && \
+      		ar -r libgcc_eh.a gcc_mock.o && \
+      		cp libgcc_eh.a libgcc_s.a
+      
       	# CARGO_LINKER is provided in Makevars.ucrt for R >= 4.2
       	export CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER="$(CARGO_LINKER)" && \
-      	  cargo +$(TOOLCHAIN) build --target=$(TARGET) --lib --release --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
+      		export LIBRARY_PATH="$${LIBRARY_PATH};$(CURDIR)/$(TARGET_DIR)/libgcc_mock" && \
+      		cargo +$(TOOLCHAIN) build --target=$(TARGET) --lib --release --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
       
       C_clean:
       	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS)

--- a/tests/testthat/_snaps/use_extendr.md
+++ b/tests/testthat/_snaps/use_extendr.md
@@ -32,58 +32,6 @@
 ---
 
     Code
-      cat_file("src", "Makevars")
-    Output
-      TARGET_DIR = ./rust/target
-      LIBDIR = $(TARGET_DIR)/release
-      STATLIB = $(LIBDIR)/libtestpkg.a
-      PKG_LIBS = -L$(LIBDIR) -ltestpkg
-      
-      all: C_clean
-      
-      $(SHLIB): $(STATLIB)
-      
-      $(STATLIB):
-      	# In some environments, ~/.cargo/bin might not be included in PATH, so we need
-      	# to set it here to ensure cargo can be invoked. It is appended to PATH and
-      	# therefore is only used if cargo is absent from the user's PATH.
-      	export PATH="$(PATH):$(HOME)/.cargo/bin" && \
-      		cargo build --lib --release --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
-      
-      C_clean:
-      	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS)
-      
-      clean:
-      	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS) rust/target
-
----
-
-    Code
-      cat_file("src", "Makevars.win")
-    Output
-      TARGET = $(subst 64,x86_64,$(subst 32,i686,$(WIN)))-pc-windows-gnu
-      TOOLCHAIN = stable-msvc
-      TARGET_DIR = ./rust/target
-      LIBDIR = $(TARGET_DIR)/$(TARGET)/release
-      STATLIB = $(LIBDIR)/libtestpkg.a
-      PKG_LIBS = -L$(LIBDIR) -ltestpkg -lws2_32 -ladvapi32 -luserenv -lbcrypt
-      
-      all: C_clean
-      
-      $(SHLIB): $(STATLIB)
-      
-      $(STATLIB):
-      	cargo +$(TOOLCHAIN) build --target=$(TARGET) --lib --release --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
-      
-      C_clean:
-      	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS)
-      
-      clean:
-      	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS) rust/target
-
----
-
-    Code
       cat_file("src", "entrypoint.c")
     Output
       // We need to forward routine registration from C to Rust
@@ -133,4 +81,61 @@
           mod testpkg;
           fn hello_world;
       }
+
+---
+
+    Code
+      cat_file("src", "Makevars")
+    Output
+      TARGET_DIR = ./rust/target
+      LIBDIR = $(TARGET_DIR)/release
+      STATLIB = $(LIBDIR)/libtestpkg.a
+      PKG_LIBS = -L$(LIBDIR) -ltestpkg
+      
+      all: C_clean
+      
+      $(SHLIB): $(STATLIB)
+      
+      $(STATLIB):
+      	# In some environments, ~/.cargo/bin might not be included in PATH, so we need
+      	# to set it here to ensure cargo can be invoked. It is appended to PATH and
+      	# therefore is only used if cargo is absent from the user's PATH.
+      	export PATH="$(PATH):$(HOME)/.cargo/bin" && \
+      		cargo build --lib --release --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
+      
+      C_clean:
+      	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS)
+      
+      clean:
+      	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS) rust/target
+
+---
+
+    Code
+      cat_file("src", "Makevars.win")
+    Output
+      TARGET = $(subst 64,x86_64,$(subst 32,i686,$(WIN)))-pc-windows-gnu
+      
+      # This is provided in Makevars.ucrt for R >= 4.2
+      TOOLCHAIN ?= stable-msvc
+      
+      TARGET_DIR = ./rust/target
+      LIBDIR = $(TARGET_DIR)/$(TARGET)/release
+      STATLIB = $(LIBDIR)/libtestpkg.a
+      PKG_LIBS = -L$(LIBDIR) -ltestpkg -lws2_32 -ladvapi32 -luserenv -lbcrypt
+      
+      all: C_clean
+      
+      $(SHLIB): $(STATLIB)
+      
+      $(STATLIB):
+      	# CARGO_LINKER is provided in Makevars.ucrt for R >= 4.2
+      	export CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER="$(CARGO_LINKER)" && \
+      	  cargo +$(TOOLCHAIN) build --target=$(TARGET) --lib --release --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
+      
+      C_clean:
+      	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS)
+      
+      clean:
+      	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS) rust/target
 

--- a/tests/testthat/test-use_extendr.R
+++ b/tests/testthat/test-use_extendr.R
@@ -10,11 +10,15 @@ test_that("use_extendr() sets up extendr files correctly", {
   expect_true(dir.exists(file.path("src", "rust", "src")))
 
   expect_snapshot(cat_file("R", "extendr-wrappers.R"))
-  expect_snapshot(cat_file("src", "Makevars"))
-  expect_snapshot(cat_file("src", "Makevars.win"))
   expect_snapshot(cat_file("src", "entrypoint.c"))
   expect_snapshot(cat_file("src", "rust", "Cargo.toml"))
   expect_snapshot(cat_file("src", "rust", "src", "lib.rs"))
+  expect_snapshot(cat_file("src", "Makevars"))
+
+  # These files diverge before and after R 4.2
+  skip_if_not(identical(R.version$crt, "ucrt"))
+  expect_snapshot(cat_file("src", "Makevars.win"))
+  expect_snapshot(cat_file("src", "Makevars.ucrt"))
 })
 
 test_that("use_extendr() does not set up packages with pre-existing src", {

--- a/tests/testthat/test-use_extendr.R
+++ b/tests/testthat/test-use_extendr.R
@@ -11,14 +11,11 @@ test_that("use_extendr() sets up extendr files correctly", {
 
   expect_snapshot(cat_file("R", "extendr-wrappers.R"))
   expect_snapshot(cat_file("src", "entrypoint.c"))
-  expect_snapshot(cat_file("src", "rust", "Cargo.toml"))
-  expect_snapshot(cat_file("src", "rust", "src", "lib.rs"))
   expect_snapshot(cat_file("src", "Makevars"))
-
-  # These files diverge before and after R 4.2
-  skip_if_not(identical(R.version$crt, "ucrt"))
   expect_snapshot(cat_file("src", "Makevars.win"))
   expect_snapshot(cat_file("src", "Makevars.ucrt"))
+  expect_snapshot(cat_file("src", "rust", "Cargo.toml"))
+  expect_snapshot(cat_file("src", "rust", "src", "lib.rs"))
 })
 
 test_that("use_extendr() does not set up packages with pre-existing src", {

--- a/tests/testthat/test-use_extendr.R
+++ b/tests/testthat/test-use_extendr.R
@@ -10,10 +10,10 @@ test_that("use_extendr() sets up extendr files correctly", {
   expect_true(dir.exists(file.path("src", "rust", "src")))
 
   expect_snapshot(cat_file("R", "extendr-wrappers.R"))
-  expect_snapshot(cat_file("src", "entrypoint.c"))
   expect_snapshot(cat_file("src", "Makevars"))
   expect_snapshot(cat_file("src", "Makevars.win"))
   expect_snapshot(cat_file("src", "Makevars.ucrt"))
+  expect_snapshot(cat_file("src", "entrypoint.c"))
   expect_snapshot(cat_file("src", "rust", "Cargo.toml"))
   expect_snapshot(cat_file("src", "rust", "src", "lib.rs"))
 })

--- a/tests/testthat/test-use_extendr.R
+++ b/tests/testthat/test-use_extendr.R
@@ -82,7 +82,7 @@ test_that("use_rextendr_template() works when usethis not available", {
 # The check is performed by compiling the sample package and checking that
 # `hello_world()` template function is available and works.
 test_that("use_extendr() handles R packages with dots in the name", {
-  path <- local_package("package.with.dots")
+  path <- local_package("a.b.c")
   use_extendr()
   document()
   document()


### PR DESCRIPTION
This pull request is the successor of #171.

Note that this pull request assumes we use `stable-gnu` on R-devel because it's difficult to support both, but we don't decide which to use `stable-gnu` or `stable-msvc`. If we choose the latter, I'll rewrite the corresponding codes.