### PR TITLE
Invoke ./configure.ucrt to ensure inst/libgcc_mock exists

### DIFF
--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -3,4 +3,4 @@ old_test_settings <- options(
 )
 
 # Ensure inst/libgcc_mock exists
-pkgbuild::compile_dll(force = TRUE)
+pkgbuild::compile_dll(force = TRUE, quiet = TRUE)

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -2,5 +2,6 @@ old_test_settings <- options(
   usethis.quiet = TRUE
 )
 
-# Ensure inst/libgcc_mock exists
+# Ensure inst/libgcc_mock exists (Note that `quiet = TRUE` seems mandatory here,
+# otherwise it crashes probably because of broken pipe?)
 pkgbuild::compile_dll(force = TRUE, quiet = TRUE)

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,3 +1,6 @@
 old_test_settings <- options(
   usethis.quiet = TRUE
 )
+
+# Ensure inst/libgcc_mock exists
+pkgbuild::compile_dll(force = TRUE)


### PR DESCRIPTION
Fix #198 