### PR TITLE
Bump rlang version to solve long stack trace display issue.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -50,7 +50,7 @@ Imports:
     pkgbuild,
     processx,
     purrr,
-    rlang (>= 1.0.0),
+    rlang (>= 1.0.5),
     rprojroot,
     stringi,
     tibble,

--- a/tests/testthat/test-document.R
+++ b/tests/testthat/test-document.R
@@ -5,8 +5,8 @@ test_that("Running `document` after adding multiple files", {
   rextendr::use_extendr()
   expect_error(rextendr::document(), NA)
 
-  file.create(glue("{path}src/rust/src/a.rs"))
-  file.create(glue("{path}src/rust/src/b.rs"))
+  file.create(file.path(path, "src/rust/src/a.rs"))
+  file.create(file.path(path, "src/rust/src/b.rs"))
 
   expect_error(rextendr::document(), NA)
 })


### PR DESCRIPTION
Closes #205.
I noticed that the error actually came from `{rlang}` and it got fixed today with a fresh release, so bumping the minimum version of rlang to `v1.0.5`.
Also I found an issue in how temp file paths are constructed in one of the tests -- it caused warnings on Windows, so I also fixed that.