### PR TITLE
Allow controlling Rust toolchain via TOOLCHAIN env variable

### DIFF
--- a/inst/templates/Makevars.ucrt
+++ b/inst/templates/Makevars.ucrt
@@ -1,5 +1,5 @@
 # Use GNU toolchain for R >= 4.2
-TOOLCHAIN = stable-gnu
+TOOLCHAIN ?= stable-gnu
 
 # Rtools42 doesn't have the linker in the location that cargo expects, so we
 # need to overwrite it via configuration.

--- a/tests/testthat/_snaps/use_extendr.md
+++ b/tests/testthat/_snaps/use_extendr.md
@@ -101,7 +101,7 @@
       cat_file("src", "Makevars.ucrt")
     Output
       # Use GNU toolchain for R >= 4.2
-      TOOLCHAIN = stable-gnu
+      TOOLCHAIN ?= stable-gnu
       
       # Rtools42 doesn't have the linker in the location that cargo expects, so we
       # need to overwrite it via configuration.


### PR DESCRIPTION
This trivial modification of the `Makevars.ucrt` template allows propagating `TOOLCHAIN` environment variable to the package build step. While on platforms other than Windows default Rust toolchain controls how the package is built, the toolchain was hardcoded for Windows in the makevars files.

One of the usecases is an easy switch to `nightly` version of the toolchain, see e.g. https://github.com/extendr/helloextendr/pull/15.