### PR TITLE
Fix an issue of `cp` trying to copy over existing `libgcc` file

### DIFF
--- a/inst/templates/Makevars.win
+++ b/inst/templates/Makevars.win
@@ -18,7 +18,7 @@ $(STATLIB):
 		touch gcc_mock.c && \
 		gcc -c gcc_mock.c -o gcc_mock.o && \
 		ar -r libgcc_eh.a gcc_mock.o && \
-		cp libgcc_eh.a libgcc_s.a
+		cp -n libgcc_eh.a libgcc_s.a
 
 	# CARGO_LINKER is provided in Makevars.ucrt for R >= 4.2
 	export CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER="$(CARGO_LINKER)" && \

--- a/tests/testthat/_snaps/use_extendr.md
+++ b/tests/testthat/_snaps/use_extendr.md
@@ -82,7 +82,7 @@
       		touch gcc_mock.c && \
       		gcc -c gcc_mock.c -o gcc_mock.o && \
       		ar -r libgcc_eh.a gcc_mock.o && \
-      		cp libgcc_eh.a libgcc_s.a
+      		cp -n libgcc_eh.a libgcc_s.a
       
       	# CARGO_LINKER is provided in Makevars.ucrt for R >= 4.2
       	export CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER="$(CARGO_LINKER)" && \


### PR DESCRIPTION
Fixes #209.
Add `-n` option to `cp` to avoid copying if the target file already exists. 

See e.g. https://github.com/extendr/rextendr/actions/runs/3255637727/jobs/5345165032#step:9:220