### PR TITLE
[PoC] Do not specify the toolchain on Windows with R >= 4.2

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -17,7 +17,9 @@ jobs:
       matrix:
         config:
           - {os: windows-latest, r: 'release', rust-version: 'stable-gnu',  rtools-version: '42'}
+          - {os: windows-latest, r: 'release', rust-version: 'stable-msvc', rtools-version: '42'}
           - {os: windows-latest, r: 'devel',   rust-version: 'stable-gnu',  rtools-version: '42'}
+          - {os: windows-latest, r: 'devel',   rust-version: 'stable-msvc', rtools-version: '42'}
           # For R < 4.2, the MSVC toolchain is used to support cross-compilation for the 32-bit.
           # TODO: Remove this runner when we drop the support for R < 4.2
           - {os: windows-latest, r: '4.1',     rust-version: 'stable-msvc'}

--- a/.github/workflows/test_pkg_gen.yaml
+++ b/.github/workflows/test_pkg_gen.yaml
@@ -20,8 +20,10 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: windows-latest, r: 'release', rust-version: 'stable-gnu', rtools-version: '42'}
-          - {os: windows-latest, r: 'devel',   rust-version: 'stable-gnu', rtools-version: '42'}
+          - {os: windows-latest, r: 'release', rust-version: 'stable-gnu',  rtools-version: '42'}
+          - {os: windows-latest, r: 'release', rust-version: 'stable-msvc', rtools-version: '42'}
+          - {os: windows-latest, r: 'devel',   rust-version: 'stable-gnu',  rtools-version: '42'}
+          - {os: windows-latest, r: 'devel',   rust-version: 'stable-msvc', rtools-version: '42'}
           # For R < 4.2, the MSVC toolchain is used to support cross-compilation for the 32-bit.
           # TODO: Remove this runner when we drop the support for R < 4.2
           - {os: windows-latest, r: '4.1',     rust-version: 'stable-msvc'}

--- a/inst/templates/Makevars.ucrt
+++ b/inst/templates/Makevars.ucrt
@@ -1,5 +1,5 @@
-# Use GNU toolchain for R >= 4.2
-TOOLCHAIN ?= stable-gnu
+# The default toolchain is used whether it's GNU or MSVC.
+TOOLCHAIN ?= stable
 
 # Rtools42 doesn't have the linker in the location that cargo expects, so we
 # need to overwrite it via configuration.

--- a/tests/testthat/_snaps/use_extendr.md
+++ b/tests/testthat/_snaps/use_extendr.md
@@ -107,8 +107,7 @@
     Code
       cat_file("src", "Makevars.ucrt")
     Output
-      # Use GNU toolchain for R >= 4.2
-      TOOLCHAIN ?= stable-gnu
+      TOOLCHAIN ?= stable
       
       # Rtools42 doesn't have the linker in the location that cargo expects, so we
       # need to overwrite it via configuration.


### PR DESCRIPTION
Related to https://github.com/extendr/extendr/issues/437

The main purpose of this pull request is to see if it works both with the GNU toolchain and with the MSVC toolchain on Windows with R >= 4.2.

Note that, to support R 4.1, we need to specify `TOOLCHAIN` anyway to make sure the GNU toolchain is used on R 4.1. In other words, if we decide to drop R 4.1, the code can be simplified more.