### PR TITLE
Deprecate rextendr::document() in favor of devtools::document()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -47,7 +47,7 @@ Imports:
     dplyr,
     glue,
     jsonlite,
-    pkgbuild,
+    pkgbuild (>= 1.4.0),
     processx,
     purrr,
     rlang (>= 1.0.5),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -47,6 +47,7 @@ Imports:
     dplyr,
     glue,
     jsonlite,
+    lifecycle,
     pkgbuild (>= 1.4.0),
     processx,
     purrr,
@@ -69,6 +70,6 @@ Config/testthat/edition: 3
 Config/testthat/parallel: true
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.3
 SystemRequirements: Rust 'cargo'; the crate 'libR-sys' must compile
     without error

--- a/R/register_extendr.R
+++ b/R/register_extendr.R
@@ -51,7 +51,7 @@ register_extendr <- function(path = ".", quiet = FALSE, force = FALSE, compile =
 
   # If compile is NA, compile if the DLL is newer than the source files
   if (isTRUE(is.na(compile))) {
-    compile <- needs_compilation(path, quiet) || pkgbuild::needs_compile(path)
+    compile <- pkgbuild::needs_compile(path)
   }
 
   if (isTRUE(compile)) {

--- a/R/rextendr_document.R
+++ b/R/rextendr_document.R
@@ -1,7 +1,5 @@
 #' Compile Rust code and generate package documentation.
 #'
-#' `r lifecycle::badge("superseded")`
-#'
 #' `rextendr::document()` was a wrapper for [devtools::document()] to ensure
 #' that Rust code is recompiled (when necessary) and that up-to-date R wrappers
 #' are generated before re-generating the package documentation. However, as of

--- a/R/rextendr_document.R
+++ b/R/rextendr_document.R
@@ -1,21 +1,16 @@
 #' Compile Rust code and generate package documentation.
 #'
-#' The function `rextendr::document()` updates the package documentation for an
-#' R package that uses `extendr` code, taking into account any changes that were
-#' made in the Rust code. It is a wrapper for [devtools::document()], and it
-#' executes `extendr`-specific routines before calling [devtools::document()].
-#' Specifically, it ensures that Rust code is recompiled (when necessary) and that
-#' up-to-date R wrappers are generated before re-generating the package documentation.
+#' `r lifecycle::badge("superseded")`
+#'
+#' `rextendr::document()` was a wrapper for [devtools::document()] to ensure
+#' that Rust code is recompiled (when necessary) and that up-to-date R wrappers
+#' are generated before re-generating the package documentation. However, as of
+#' pkgdown 1.4.0, `devtools::document()` detects the changes on Rust code, so
+#' the users can rely on it directly.
 #' @inheritParams devtools::document
 #' @return No return value, called for side effects.
 #' @export
 document <- function(pkg = ".", quiet = getOption("usethis.quiet", FALSE), roclets = NULL) {
-  try_save_all(quiet = quiet)
-
-  withr::local_envvar(devtools::r_env_vars())
-
-  register_extendr(path = pkg, quiet = quiet)
-
-  rlang::check_installed("devtools")
+  lifecycle::deprecate_soft("0.3.0", "rextendr::document()", "devtools::document()")
   devtools::document(pkg = pkg, roclets = roclets, quiet = FALSE)
 }

--- a/R/track_rust_source.R
+++ b/R/track_rust_source.R
@@ -82,9 +82,9 @@ pretty_rel_single_path <- function(path, search_from = ".") {
 }
 
 #' See [pretty_rel_single_path] for implementation details
-#' 
+#'
 #' @inheritParams pretty_rel_single_path
-#' 
+#'
 #' @noRd
 pretty_rel_path <- function(path, search_from = ".") {
    purrr::map_chr(path, pretty_rel_single_path, search_from = search_from)
@@ -133,49 +133,6 @@ get_rust_files <- function(path = ".") {
 
   result <- c(cargo_toml_paths, rust_src_paths)
   result
-}
-
-#' Checks if re-compilation is needed.
-#'
-#' Tracks changes in Rust source files (`*.rs`) and `Cargo.toml`.
-#' @param path Path from which package root is looked up.
-#' @param quiet Logical scalar indicating wether the output should be quiet (`TRUE`)
-#'   or verbose (`FALSE`).
-#' @returns Logical `TRUE` if Rust source has been modified, `FALSE` otherwise.
-#' @noRd
-needs_compilation <- function(path = ".", quiet = getOption("usethis.quiet", FALSE)) {
-  library_path <- get_library_path(path)
-
-  # This will likely never happen.
-  # Shortcut: missing library file requires compilation in any case.
-  if (!file.exists(library_path)) {
-    if (!isTRUE(quiet)) {
-      library_path_rel <- pretty_rel_path(library_path, path)
-      ui_w("No library found at {.file {library_path_rel}}, recompilation is required.")
-    }
-    return(TRUE)
-  }
-
-  # Leaves files that were modified *after* the library
-  modified_files_paths <- find_newer_files_than(get_rust_files(path), library_path)
-
-  # Shortcut: no files have been modified since last compilation.
-  if (length(modified_files_paths) == 0L) {
-    return(FALSE)
-  }
-
-  # Takes relative to the project root paths of all modified files and walks it,
-  # informing user of each modification.
-  # This perhaps should have an `isFALSE(quiet)` check, but right now rextendr rocelts
-  # do not support `quiet` arg.
-  if (!isTRUE(quiet)) {
-    purrr::walk(
-      pretty_rel_path(modified_files_paths, search_from = path),
-      ~ ui_i("File {.file {.x}} has been modified since last compilation.")
-    )
-  }
-
-  TRUE
 }
 
 #' Equivalent to `fs::file_info`.

--- a/man/document.Rd
+++ b/man/document.Rd
@@ -20,9 +20,6 @@ which defaults to \code{c("collate", "namespace", "rd")}.}
 No return value, called for side effects.
 }
 \description{
-\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#superseded}{\figure{lifecycle-superseded.svg}{options: alt='[Superseded]'}}}{\strong{[Superseded]}}
-}
-\details{
 \code{rextendr::document()} was a wrapper for \code{\link[devtools:document]{devtools::document()}} to ensure
 that Rust code is recompiled (when necessary) and that up-to-date R wrappers
 are generated before re-generating the package documentation. However, as of

--- a/man/document.Rd
+++ b/man/document.Rd
@@ -20,10 +20,12 @@ which defaults to \code{c("collate", "namespace", "rd")}.}
 No return value, called for side effects.
 }
 \description{
-The function \code{rextendr::document()} updates the package documentation for an
-R package that uses \code{extendr} code, taking into account any changes that were
-made in the Rust code. It is a wrapper for \code{\link[devtools:document]{devtools::document()}}, and it
-executes \code{extendr}-specific routines before calling \code{\link[devtools:document]{devtools::document()}}.
-Specifically, it ensures that Rust code is recompiled (when necessary) and that
-up-to-date R wrappers are generated before re-generating the package documentation.
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#superseded}{\figure{lifecycle-superseded.svg}{options: alt='[Superseded]'}}}{\strong{[Superseded]}}
+}
+\details{
+\code{rextendr::document()} was a wrapper for \code{\link[devtools:document]{devtools::document()}} to ensure
+that Rust code is recompiled (when necessary) and that up-to-date R wrappers
+are generated before re-generating the package documentation. However, as of
+pkgdown 1.4.0, \code{devtools::document()} detects the changes on Rust code, so
+the users can rely on it directly.
 }


### PR DESCRIPTION
Fix #215 

* Deprecate `document()`
* Remove `needs_compilation()`