### PR TITLE
added optimisations to Cargo.toml

### DIFF
--- a/R/use_extendr.R
+++ b/R/use_extendr.R
@@ -105,7 +105,8 @@ use_extendr <- function(path = ".",
   cargo_toml_content <- to_toml(
     package = list(name = crate_name, version = "0.1.0", edition = edition),
     lib = list(`crate-type` = array("staticlib", 1), name = lib_name),
-    dependencies = list(`extendr-api` = "*")
+    dependencies = list(`extendr-api` = "*"),
+    profile.release = list(`opt-level` = 'z', lto = TRUE)
   )
 
   write_file(


### PR DESCRIPTION
Adds some compiler optimisations to Cargo.toml. This should remove the R CMD CHECK NOTE on the compiled code being very large.