### PR TITLE
Use Rtools43

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -25,7 +25,7 @@ jobs:
           # * for R < 4.2, the MSVC toolchain must be used to support
           #   cross-compilation for the 32-bit.
           - {os: windows-latest, r: 'release', rust-version: 'stable-msvc', rtools-version: '42'}
-          - {os: windows-latest, r: 'devel',   rust-version: 'stable-msvc', rtools-version: '42'}
+          - {os: windows-latest, r: 'devel',   rust-version: 'stable-msvc'}
           - {os: windows-latest, r: 'release', rust-version: 'stable-gnu',  rtools-version: '42'}
           - {os: windows-latest, r: '4.1',     rust-version: 'stable-msvc'}  # TODO: Remove this runner when we drop the support for R < 4.2
 

--- a/.github/workflows/test_pkg_gen.yaml
+++ b/.github/workflows/test_pkg_gen.yaml
@@ -22,8 +22,7 @@ jobs:
         config:
           - {os: windows-latest, r: 'release', rust-version: 'stable-gnu',  rtools-version: '42'}
           - {os: windows-latest, r: 'release', rust-version: 'stable-msvc', rtools-version: '42'}
-          - {os: windows-latest, r: 'devel',   rust-version: 'stable-gnu',  rtools-version: '42'}
-          - {os: windows-latest, r: 'devel',   rust-version: 'stable-msvc', rtools-version: '42'}
+          - {os: windows-latest, r: 'devel',   rust-version: 'stable-msvc'}
           # For R < 4.2, the MSVC toolchain is used to support cross-compilation for the 32-bit.
           # TODO: Remove this runner when we drop the support for R < 4.2
           - {os: windows-latest, r: '4.1',     rust-version: 'stable-msvc'}

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * Ilia Kosenkov is now the official maintainer.
 
+* Support Rtools43 (#231).
+
 ## New features
 
 * A `<pkg_name>-win.def` file containing DLL exports is created by `rextendr::use_extendr()`. It is used during linking phase on Windows and solves the problem of compiling very large projects, such as `polars` ([#212](https://github.com/extendr/rextendr/pull/212))

--- a/R/source.R
+++ b/R/source.R
@@ -260,14 +260,13 @@ invoke_cargo <- function(toolchain, specific_target, dir, profile,
       }
 
       if (package_version(R.version$minor) >= "3.0") {
-        rtools_version <- "43"
+        rtools_version <- "43"  # nolint: object_usage_linter
       } else {
-        rtools_version <- "42"
+        rtools_version <- "42"  # nolint: object_usage_linter
       }
 
-      # RTOOLS4x_HOME must be set by R itself as it's embeded in R's source code.
-      # c.f. https://github.com/wch/r-source/blob/b29a18150688fb1af338ab9a3d1a3782006a622e/src/library/profile/Rprofile.windows#L73 # nolint: line_length_linter
-      rtools_home <- Sys.getenv(paste0("RTOOLS", rtools_version, "_HOME"))
+      rtools_home <- Sys.getenv(glue("RTOOLS{rtools_version}_HOME"),
+                                glue("C:\\rtools{rtools_version}"))
 
       # c.f. https://github.com/wch/r-source/blob/f09d3d7fa4af446ad59a375d914a0daf3ffc4372/src/library/profile/Rprofile.windows#L70-L71 # nolint: line_length_linter
       subdir <- c("x86_64-w64-mingw32.static.posix", "usr")

--- a/R/source.R
+++ b/R/source.R
@@ -265,8 +265,13 @@ invoke_cargo <- function(toolchain, specific_target, dir, profile,
         rtools_version <- "42"  # nolint: object_usage_linter
       }
 
-      rtools_home <- Sys.getenv(glue("RTOOLS{rtools_version}_HOME"),
-                                glue("C:\\rtools{rtools_version}"))
+      rtools_home <- normalizePath(
+        Sys.getenv(
+          glue("RTOOLS{rtools_version}_HOME"),
+          glue("C:\\rtools{rtools_version}")
+        ),
+        mustWork = TRUE
+      )
 
       # c.f. https://github.com/wch/r-source/blob/f09d3d7fa4af446ad59a375d914a0daf3ffc4372/src/library/profile/Rprofile.windows#L70-L71 # nolint: line_length_linter
       subdir <- c("x86_64-w64-mingw32.static.posix", "usr")

--- a/R/source.R
+++ b/R/source.R
@@ -267,7 +267,7 @@ invoke_cargo <- function(toolchain, specific_target, dir, profile,
 
       # RTOOLS4x_HOME must be set by R itself as it's embeded in R's source code.
       # c.f. https://github.com/wch/r-source/blob/b29a18150688fb1af338ab9a3d1a3782006a622e/src/library/profile/Rprofile.windows#L73 # nolint: line_length_linter
-      rtools_home <- Sys.getenv(glue("RTOOLS{rtools_version}_HOME"))
+      rtools_home <- Sys.getenv(paste0("RTOOLS", rtools_version, "_HOME"))
 
       # c.f. https://github.com/wch/r-source/blob/f09d3d7fa4af446ad59a375d914a0daf3ffc4372/src/library/profile/Rprofile.windows#L70-L71 # nolint: line_length_linter
       subdir <- c("x86_64-w64-mingw32.static.posix", "usr")


### PR DESCRIPTION
This pull request is a part of https://github.com/extendr/extendr/issues/442.

r-lib/actions now supports Rtools43 and uses it by default for R > 4.2 (c.f. https://github.com/r-lib/actions/commit/740a0e7ce930b6357f16388c0b2acee8337adb01). So, this pull request removes the specification of `rtools-version: '42'` on the R-devel runners.

Also, this pull request stops relying on pkgbuild to detect `RTOOLS4x_HOME` for R >=4.2. pkgbuild doesn't support Rtools43 yet, and all it does is just to check `RTOOLS4x_HOME` ([source code](https://github.com/r-lib/pkgbuild/blob/11cb9e901582246ff62769d6339e6d1d01a4e4c6/R/rtools.R#L35-L44)), so we can simply do the same thing.