### PR TITLE
Re-enable the test disabled by #240

### DIFF
--- a/tests/testthat/test-pretty_rel_path.R
+++ b/tests/testthat/test-pretty_rel_path.R
@@ -34,8 +34,6 @@ test_that("Find relative path starting outside of package directory, return abso
   pkg_root <- local_package("testpkg")
   use_extendr()
 
-  r_version <- as.numeric_version(glue::glue("{R.version$major}.{R.version$minor}"))
-  is_windows <- .Platform$OS.type == "windows"
 
   expect_equal(
     pretty_rel_path(

--- a/tests/testthat/test-pretty_rel_path.R
+++ b/tests/testthat/test-pretty_rel_path.R
@@ -37,11 +37,6 @@ test_that("Find relative path starting outside of package directory, return abso
   r_version <- as.numeric_version(glue::glue("{R.version$major}.{R.version$minor}"))
   is_windows <- .Platform$OS.type == "windows"
 
-  skip_if(
-    condition = is_windows && r_version >= as.numeric_version("4.3.0"),
-    message <- "Skipping flaky test on R-devel-windows, see https://github.com/extendr/rextendr/issues/238"
-  )
-
   expect_equal(
     pretty_rel_path(
       file.path(pkg_root, "R", "extendr-wrappers.R"),


### PR DESCRIPTION
The problem was fixed in R-devel, so we can enable the test again (but probably we have to wait a day or two).

https://github.com/wch/r-source/commit/d444c07b7fe765ce65224faa2e85f0819a189e1a