### PR TITLE
Remove pkg building hack

### DIFF
--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,5 +1,1 @@
 withr::local_options(usethis.quiet = TRUE, .local_envir = teardown_env())
-
-# Ensure inst/libgcc_mock exists (Note that `quiet = TRUE` seems mandatory here,
-# otherwise it crashes probably because of broken pipe?)
-pkgbuild::compile_dll(force = TRUE, quiet = TRUE)


### PR DESCRIPTION
Closes #257.

Remove pkgbuild package installation hack that was previously necessary, but right now is not. 