### PR TITLE
Do not add crate reference when feature is enabled

### DIFF
--- a/R/features.R
+++ b/R/features.R
@@ -2,7 +2,7 @@ features_config <- rlang::env(
   known_features = c("ndarray", "serde", "num-complex", "num-complex", "graphics")
 )
 
-validate_extendr_features <- function(features, quiet) {
+validate_extendr_features <- function(features, suppress_warnings) {
   features <- features %||% character(0)
   vctrs::vec_assert(features, character())
   features <- unique(features)
@@ -11,8 +11,7 @@ validate_extendr_features <- function(features, quiet) {
     setdiff(features_config$known_features) %>%
     discard_empty()
 
-  # TODO: Fox this
-  if (!isTRUE(quiet) && length(unknown_features) > 0) {
+  if (!isTRUE(suppress_warnings) && length(unknown_features) > 0) {
     cli::cli_warn(c(
       "Found unknown {.code extendr} feature{?s}: {.val {unknown_features}}.",
       inf_dev_extendr_used() # nolint: object_usage_linter

--- a/R/features.R
+++ b/R/features.R
@@ -1,18 +1,5 @@
 features_config <- rlang::env(
-  known_features = tibble::tribble(
-    ~Name, ~RequiresPackage, ~Package,
-    "ndarray", TRUE, "ndarray",
-    "serde", TRUE, "serde",
-    "num-complex", TRUE, "num-complex",
-    "graphics", FALSE, NA
-  )
-)
-features_config[["known_features"]] <- tibble::tribble(
-  ~Name, ~RequiresPackage, ~Package,
-  "ndarray", TRUE, "ndarray",
-  "serde", TRUE, "serde",
-  "num-complex", TRUE, "num-complex",
-  "graphics", FALSE, NA
+  known_features = c("ndarray", "serde", "num-complex", "num-complex", "graphics")
 )
 
 validate_extendr_features <- function(features, quiet) {
@@ -21,9 +8,10 @@ validate_extendr_features <- function(features, quiet) {
   features <- unique(features)
 
   unknown_features <- features %>%
-    setdiff(features_config$known_features$Name) %>%
+    setdiff(features_config$known_features) %>%
     discard_empty()
 
+  # TODO: Fox this
   if (!isTRUE(quiet) && length(unknown_features) > 0) {
     cli::cli_warn(c(
       "Found unknown {.code extendr} feature{?s}: {.val {unknown_features}}.",
@@ -61,18 +49,4 @@ enable_features <- function(extendr_deps, features) {
   extendr_deps[["extendr-api"]] <- extendr_api
 
   extendr_deps
-}
-
-add_features_dependencies <- function(dependencies, features) {
-  required_packages <- features_config$known_features %>%
-    dplyr::filter(
-      vctrs::vec_in(needles = .data$Name, haystack = features) &
-        .data$RequiresPackage
-    ) %>%
-    dplyr::pull(.data$Package)
-
-  feature_deps <- rep(list("*"), length(required_packages))
-  names(feature_deps) <- required_packages
-
-  purrr::list_modify(feature_deps, !!!dependencies)
 }

--- a/R/generate_toml.R
+++ b/R/generate_toml.R
@@ -14,7 +14,7 @@ generate_cargo.toml <- function(libname = "rextendr",
       `crate-type` = array("cdylib", 1)
     ),
     dependencies = purrr::list_modify(
-      add_features_dependencies(dependencies, features),
+      dependencies %||% list(),
       !!!enable_features(extendr_deps, features)
     ),
     `patch.crates-io` = patch.crates_io,

--- a/R/source.R
+++ b/R/source.R
@@ -114,7 +114,7 @@ rust_source <- function(file, code = NULL,
                         use_rtools = TRUE,
                         use_dev_extendr = FALSE) {
   profile <- rlang::arg_match(profile, multiple = FALSE)
-  features <- validate_extendr_features(features, quiet)
+  features <- validate_extendr_features(features, suppress_warnings = isTRUE(quiet) || isTRUE(use_dev_extendr))
 
   if (is.null(extendr_deps)) {
     if (isTRUE(use_dev_extendr)) {

--- a/tests/testthat/test-optional-features.R
+++ b/tests/testthat/test-optional-features.R
@@ -12,51 +12,6 @@ test_that("Feature 'ndarray' is enabled when no extra dependencies are specified
   expect_equal(actual_sum, expected_sum)
 })
 
-test_that("Feature 'ndarray' is enabled when dependency is explicitly set", {
-  input <- file.path("../data/ndarray_example.rs")
-  rust_source(
-    file = input,
-    features = "ndarray",
-    dependencies = list(ndarray = "*")
-  )
-
-  data <- matrix(runif(100L), 25)
-  expected_sum <- sum(data)
-  actual_sum <- matrix_sum(data)
-
-  expect_equal(actual_sum, expected_sum)
-})
-
-test_that("Feature 'ndarray' is enabled when dependency is explicitly set to a complex value", {
-  input <- file.path("../data/ndarray_example.rs")
-  rust_source(
-    file = input,
-    features = "ndarray",
-    dependencies = list(ndarray = list(version = "*"))
-  )
-
-  data <- matrix(runif(100L), 25)
-  expected_sum <- sum(data)
-  actual_sum <- matrix_sum(data)
-
-  expect_equal(actual_sum, expected_sum)
-})
-
-test_that("Feature 'ndarray' is enabled when other dependencies are specified", {
-  input <- file.path("../data/ndarray_example.rs")
-  rust_source(
-    file = input,
-    features = "ndarray",
-    dependencies = list(either = list(version = "*"))
-  )
-
-  data <- matrix(runif(100L), 25)
-  expected_sum <- sum(data)
-  actual_sum <- matrix_sum(data)
-
-  expect_equal(actual_sum, expected_sum)
-})
-
 test_that("Feature 'ndarray' is enabled when 'extendr-api' has features enabled", {
   input <- file.path("../data/ndarray_example.rs")
   rust_source(

--- a/tests/testthat/test-optional-features.R
+++ b/tests/testthat/test-optional-features.R
@@ -39,3 +39,28 @@ test_that("Passing integers to `features` results in error", {
 test_that("Passing list to `features` results in error", {
   expect_error(rust_function("fn test() {}", features = list()))
 })
+
+test_that("Enabling experimental feature raises warning", {
+  expect_warning(
+    rust_function(
+      "fn test_either(_x : Either<Integers, Doubles>) {}",
+      features = "either",
+      # either works only with `use_try_from = TRUE`
+      extendr_fn_options = list(use_try_from = TRUE),
+      # manually override dependency to avoid setting `use_dev_extendr = TRUE`
+      patch.crates_io = list("extendr-api" = list(git = "https://github.com/extendr/extendr"))
+    )
+  )
+})
+
+test_that("Enabling experimental feature does not raise warning if `use_dev_extendr` is `TRUE`", {
+  expect_no_warning(
+    rust_function(
+      "fn test_either(_x : Either<Integers, Doubles>) {}",
+      features = "either",
+      # either works only with `use_try_from = TRUE`
+      extendr_fn_options = list(use_try_from = TRUE),
+      use_dev_extendr = TRUE
+    )
+  )
+})


### PR DESCRIPTION
`extendr` re-exports crates when they are behind a feature gate, so there is no real need to automatically add reference for third-party crates.

Also update how warnings are raised, following the example of `extendr_fn_options`, not raising warnings when `use_dev_extendr = TRUE`.