### PR TITLE
[R-4.3] Fix CI

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -40,7 +40,7 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.config.rust-version }}
-          targets: ${{  matrux.config.rust-target }}
+          targets: ${{  matrix.config.rust-target }}
 
       - uses: r-lib/actions/setup-r@v2
         with:

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -18,7 +18,7 @@ jobs:
         config:
           - {os: windows-latest, r: 'release', rust-version: 'stable-msvc', rust-target: 'x86_64-pc-windows-gnu' }
           - {os: windows-latest, r: 'devel',   rust-version: 'stable-msvc', rust-target: 'x86_64-pc-windows-gnu' }
-          - {os: windows-latest, r: 'oldrel',  rust-version: 'stable-msvc', rust-target: 'x86_64-pc-windows-gnu' }
+          - {os: windows-latest, r: 'oldrel',  rust-version: 'stable-msvc', rust-target: 'x86_64-pc-windows-gnu', rtools-version: '42' }
 
           - {os: macOS-latest,   r: 'release', rust-version: 'stable' }
 
@@ -44,6 +44,7 @@ jobs:
       - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
+          rtools-version: ${{ matrix.config.rtools-version }}
           # TODO: enable RSPM when all the packages are available
           use-public-rspm: false
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -24,7 +24,7 @@ jobs:
 
           - {os: ubuntu-latest,  r: 'release', rust-version: 'stable' }
           - {os: ubuntu-latest,  r: 'devel',   rust-version: 'stable' }
-          - {os: ubuntu-latest,  r: 'oldrel',   rust-version: 'stable' }
+          - {os: ubuntu-latest,  r: 'oldrel',  rust-version: 'stable' }
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -36,8 +36,7 @@ jobs:
 
       - uses: r-lib/actions/setup-pandoc@v2
 
-      - name: Set up Rust
-        uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.config.rust-version }}
           targets: ${{  matrix.config.rust-target }}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,6 +1,6 @@
 on:
   push:
-    branches: [main, master]
+    branches: [main, master, 'fix/R-4-3-release']
   pull_request:
     branches: [main, master]
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -16,23 +16,15 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          # On Windows,
-          #
-          # * for R >= 4.2, both the MSVC toolchain and the GNU toolchain should
-          #   work. Since our main support is on MSVC, we mainly test MSVC here.
-          #   Also, at least one GNU case should be included so that we can
-          #   detect when something gets broken.
-          # * for R < 4.2, the MSVC toolchain must be used to support
-          #   cross-compilation for the 32-bit.
-          - {os: windows-latest, r: 'release', rust-version: 'stable-msvc', rtools-version: '42'}
-          - {os: windows-latest, r: 'devel',   rust-version: 'stable-msvc'}
-          - {os: windows-latest, r: 'release', rust-version: 'stable-gnu',  rtools-version: '42'}
-          - {os: windows-latest, r: '4.1',     rust-version: 'stable-msvc'}  # TODO: Remove this runner when we drop the support for R < 4.2
+          - {os: windows-latest, r: 'release', rust-version: 'stable-msvc', rust-target: 'x86_64-pc-windows-gnu' }
+          - {os: windows-latest, r: 'devel',   rust-version: 'stable-msvc', rust-target: 'x86_64-pc-windows-gnu' }
+          - {os: windows-latest, r: 'oldrel',  rust-version: 'stable-msvc', rust-target: 'x86_64-pc-windows-gnu' }
 
-          - {os: macOS-latest,   r: 'release', rust-version: 'stable'     }
+          - {os: macOS-latest,   r: 'release', rust-version: 'stable' }
 
-          - {os: ubuntu-latest,  r: 'release', rust-version: 'stable'     }
-          - {os: ubuntu-latest,  r: 'devel',   rust-version: 'stable'     }
+          - {os: ubuntu-latest,  r: 'release', rust-version: 'stable' }
+          - {os: ubuntu-latest,  r: 'devel',   rust-version: 'stable' }
+          - {os: ubuntu-latest,  r: 'oldrel',   rust-version: 'stable' }
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
@@ -48,31 +40,13 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.config.rust-version }}
+          targets: ${{ join(',', matrix.config.rust-target) }}
 
       - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
-          rtools-version: ${{ matrix.config.rtools-version }}
           # TODO: enable RSPM when all the packages are available
           use-public-rspm: false
-
-      - name: Configure Windows (R >= 4.2)
-        if: startsWith(runner.os, 'Windows') && matrix.config.r != '4.1'
-        run: |
-          rustup target add x86_64-pc-windows-gnu
-
-          # To confirm the tests work without the legacy toolchains, remove them
-          Remove-Item -Recurse -Force "${env:RTOOLS40_HOME}\mingw64"
-          Remove-Item -Recurse -Force "${env:RTOOLS40_HOME}\mingw32"
-          Remove-Item -Recurse -Force "${env:RTOOLS40_HOME}\ucrt64"
-
-
-      # TODO: Remove this runner when we drop the support for R < 4.2
-      - name: Configure Windows (R < 4.2)
-        if: startsWith(runner.os, 'Windows') && matrix.config.r == '4.1'
-        run: |
-          rustup target add x86_64-pc-windows-gnu
-          rustup target add i686-pc-windows-gnu
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -40,7 +40,7 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.config.rust-version }}
-          targets: ${{ join(',', matrix.config.rust-target) }}
+          targets: ${{  matrux.config.rust-target }}
 
       - uses: r-lib/actions/setup-r@v2
         with:

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -39,7 +39,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.config.rust-version }}
-          targets: ${{  matrix.config.rust-target }}
+          targets: ${{ matrix.config.rust-target }}
 
       - uses: r-lib/actions/setup-r@v2
         with:

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,6 +1,6 @@
 on:
   push:
-    branches: [main, master, 'fix/R-4-3-release']
+    branches: [main, master]
   pull_request:
     branches: [main, master]
 

--- a/.github/workflows/test_pkg_gen.yaml
+++ b/.github/workflows/test_pkg_gen.yaml
@@ -3,6 +3,7 @@ on:
     branches:
       - main
       - master
+      - fix/R-4-3-release
   pull_request:
     branches:
       - main

--- a/.github/workflows/test_pkg_gen.yaml
+++ b/.github/workflows/test_pkg_gen.yaml
@@ -38,8 +38,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up Rust
-        uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.config.rust-version }}
           targets: ${{ matrix.config.rust-target }}

--- a/.github/workflows/test_pkg_gen.yaml
+++ b/.github/workflows/test_pkg_gen.yaml
@@ -20,17 +20,15 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: windows-latest, r: 'release', rust-version: 'stable-gnu',  rtools-version: '42'}
-          - {os: windows-latest, r: 'release', rust-version: 'stable-msvc', rtools-version: '42'}
-          - {os: windows-latest, r: 'devel',   rust-version: 'stable-msvc'}
-          # For R < 4.2, the MSVC toolchain is used to support cross-compilation for the 32-bit.
-          # TODO: Remove this runner when we drop the support for R < 4.2
-          - {os: windows-latest, r: '4.1',     rust-version: 'stable-msvc'}
+          - {os: windows-latest, r: 'release', rust-version: 'stable-msvc', rust-target: 'x86_64-pc-windows-gnu'}
+          - {os: windows-latest, r: 'devel',   rust-version: 'stable-msvc', rust-target: 'x86_64-pc-windows-gnu' }
+          - {os: windows-latest, r: 'oldrel',  rust-version: 'stable-msvc', rust-target: 'x86_64-pc-windows-gnu'}
 
           - {os: macOS-latest,   r: 'release', rust-version: 'stable'}
 
           - {os: ubuntu-latest,  r: 'release', rust-version: 'stable'}
           - {os: ubuntu-latest,  r: 'devel',   rust-version: 'stable'}
+          - {os: ubuntu-latest,  r: 'oldrel',  rust-version: 'stable'}
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
@@ -43,12 +41,12 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.config.rust-version }}
+          targets: ${{ join(',', matrix.config.rust-target) }}
 
       - name: Set up R
         uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
-          rtools-version: ${{ matrix.config.rtools-version }}
           # TODO: enable RSPM when all the packages are available
           use-public-rspm: false
 
@@ -58,25 +56,8 @@ jobs:
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           # increment this version number when we need to clear the cache
-          cache-version: 2
+          cache-version: 3
           extra-packages: rcmdcheck, devtools, usethis
-
-      - name: Configure Windows (R >= 4.2)
-        if: startsWith(runner.os, 'Windows') && matrix.config.r != '4.1'
-        run: |
-          rustup target add x86_64-pc-windows-gnu
-          echo "C:\msys64\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-        shell: pwsh
-
-      # TODO: Remove this runner when we drop the support for R < 4.2
-      - name: Configure Windows (R < 4.2)
-        if: startsWith(runner.os, 'Windows') && matrix.config.r == '4.1'
-        run: |
-          rustup target add x86_64-pc-windows-gnu
-          rustup target add i686-pc-windows-gnu
-          echo "C:\msys64\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-          echo "C:\msys64\mingw32\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-        shell: pwsh
 
       - name: Test package generation
         env:

--- a/.github/workflows/test_pkg_gen.yaml
+++ b/.github/workflows/test_pkg_gen.yaml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         config:
           - {os: windows-latest, r: 'release', rust-version: 'stable-msvc', rust-target: 'x86_64-pc-windows-gnu'}
-          - {os: windows-latest, r: 'devel',   rust-version: 'stable-msvc', rust-target: 'x86_64-pc-windows-gnu' }
+          - {os: windows-latest, r: 'devel',   rust-version: 'stable-msvc', rust-target: 'x86_64-pc-windows-gnu'}
           - {os: windows-latest, r: 'oldrel',  rust-version: 'stable-msvc', rust-target: 'x86_64-pc-windows-gnu'}
 
           - {os: macOS-latest,   r: 'release', rust-version: 'stable'}
@@ -42,7 +42,7 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.config.rust-version }}
-          targets: ${{ join(',', matrix.config.rust-target) }}
+          targets: ${{ matrix.config.rust-target }}
 
       - name: Set up R
         uses: r-lib/actions/setup-r@v2

--- a/.github/workflows/test_pkg_gen.yaml
+++ b/.github/workflows/test_pkg_gen.yaml
@@ -3,7 +3,6 @@ on:
     branches:
       - main
       - master
-      - fix/R-4-3-release
   pull_request:
     branches:
       - main

--- a/.github/workflows/test_pkg_gen.yaml
+++ b/.github/workflows/test_pkg_gen.yaml
@@ -22,7 +22,7 @@ jobs:
         config:
           - {os: windows-latest, r: 'release', rust-version: 'stable-msvc', rust-target: 'x86_64-pc-windows-gnu'}
           - {os: windows-latest, r: 'devel',   rust-version: 'stable-msvc', rust-target: 'x86_64-pc-windows-gnu'}
-          - {os: windows-latest, r: 'oldrel',  rust-version: 'stable-msvc', rust-target: 'x86_64-pc-windows-gnu'}
+          - {os: windows-latest, r: 'oldrel',  rust-version: 'stable-msvc', rust-target: 'x86_64-pc-windows-gnu', rtools-version: '42'}
 
           - {os: macOS-latest,   r: 'release', rust-version: 'stable'}
 
@@ -46,6 +46,7 @@ jobs:
         uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
+          rtools-version: ${{ matrix.config.rtools-version }}
           # TODO: enable RSPM when all the packages are available
           use-public-rspm: false
 


### PR DESCRIPTION
See e.g. https://github.com/extendr/libR-sys/pull/163

R-release is now R-4.3, so there are no longer 32-bit versions of R available. 

Simplify setup and configuration, rely on ready-made workflows rather than manual configuration.