### PR TITLE
fix: ensure TRUE or FALSE

### DIFF
--- a/R/register_extendr.R
+++ b/R/register_extendr.R
@@ -78,7 +78,7 @@ register_extendr <- function(path = ".", quiet = FALSE, force = FALSE, compile =
   # by the latest DLL, which should mean it doesn't need to be re-generated.
   # This isn't always the case (e.g. when the user accidentally edited the
   # wrapper file by hand) so the user might need to run with `force = TRUE`.
-  if (!isTRUE(force) && file.info(outfile)[["mtime"]] > file.info(library_path)[["mtime"]]) {
+  if (!isTRUE(force) && isTRUE(file.info(outfile)[["mtime"]] > file.info(library_path)[["mtime"]])) {
     rel_path <- pretty_rel_path(outfile, path) # nolint: object_usage_linter
     ui_i("{.file {rel_path}} is up-to-date. Skip generating wrapper functions.")
 


### PR DESCRIPTION
The evaluation expression in this if becomes `NA` if `outfile` does not exist.

I ran into this when I deleted the extendr-wrappers.R file.