### PR TITLE
fix: ensure `find_exports` return a tibble includes name, type, lifetyme columns

### DIFF
--- a/R/find_exports.R
+++ b/R/find_exports.R
@@ -3,6 +3,11 @@ find_exports <- function(clean_lns) {
   start <- ids
   end <- dplyr::lead(ids, default = length(clean_lns) + 1L) - 1L
 
+  # start and end may empty
+  if (rlang::is_empty(start) || rlang::is_empty(end)) {
+    return(tibble::tibble(name = character(0), type = character(0), lifetime = character(0)))
+  }
+
   purrr::map2_dfr(start, end, ~ extract_meta(clean_lns[.x:.y])) %>%
     dplyr::mutate(type = dplyr::coalesce(.data$impl, .data$fn)) %>%
     dplyr::select(dplyr::all_of(c("name", "type", "lifetime")))

--- a/tests/testthat/test-source.R
+++ b/tests/testthat/test-source.R
@@ -108,3 +108,8 @@ test_that("`rust_code()` can compile code from rust files with identical names",
   expect_equal(test_method_1(), 1L)
   expect_equal(test_method_2(), 2L)
 })
+
+# https://github.com/extendr/rextendr/issues/264
+test_that("`rust_source()` should not raise internal error for code without extendr attrs", {
+  expect_no_error(rust_source(code = "fn test() {}"))
+})


### PR DESCRIPTION
Fix #264