### PR TITLE
Switch to dev version after release

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rextendr
 Title: Call Rust Code from R using the 'extendr' Crate
-Version: 0.3.0
+Version: 0.3.0.9000
 Authors@R: 
     c(person(given = "Claus O.",
              family = "Wilke",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# rextendr (development version)
+
 # rextendr 0.3.0
 
 * Ilia Kosenkov is now the official maintainer.

--- a/tests/testthat/_snaps/use_extendr.md
+++ b/tests/testthat/_snaps/use_extendr.md
@@ -4,7 +4,7 @@
       use_extendr()
     Message
       i First time using rextendr. Upgrading automatically...
-      i Setting `Config/rextendr/version` to "0.3.0"
+      i Setting `Config/rextendr/version` to "0.3.0.9000"
       v Creating 'src/rust/src'.
       v Writing 'src/entrypoint.c'
       v Writing 'src/Makevars'


### PR DESCRIPTION
`{rextendr} 0.3.0` is released. Switch to dev version (#277).