### PR TITLE
[Release 0.3.1]

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rextendr
 Title: Call Rust Code from R using the 'extendr' Crate
-Version: 0.3.0.9000
+Version: 0.3.1
 Authors@R: 
     c(person(given = "Claus O.",
              family = "Wilke",

--- a/tests/testthat/_snaps/use_extendr.md
+++ b/tests/testthat/_snaps/use_extendr.md
@@ -4,7 +4,7 @@
       use_extendr()
     Message
       i First time using rextendr. Upgrading automatically...
-      i Setting `Config/rextendr/version` to "0.3.0.9000"
+      i Setting `Config/rextendr/version` to "0.3.1"
       v Creating 'src/rust/src'.
       v Writing 'src/entrypoint.c'
       v Writing 'src/Makevars'


### PR DESCRIPTION
`{rextendr 0.3.1}` is on CRAN, pushing version bumps.

#286