### PR TITLE
ci(website): enable pkgdown auto dev mode

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,5 +1,7 @@
 template:
   bootstrap: 5
+development:
+  mode: auto
 
 destination: docs
 


### PR DESCRIPTION
See https://pkgdown.r-lib.org/reference/build_site.html#development-mode

It is better to do this setting to avoid confusion between CRAN released and unreleased versions.