### PR TITLE
feat!: set `SystemRequirements` field automatically

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # rextendr (development version)
 
+* `use_extendr()` and `document()` now set the `SystemRequirements` field of the `DESCRIPTION` file to
+  `Cargo (rustc package manager)` if the field is empty (#298).
+
 # rextend 0.3.1
 
 * Update package templates to work with Rust >= 1.70 (#285)

--- a/R/setup.R
+++ b/R/setup.R
@@ -13,8 +13,9 @@ rextendr_setup <- function(path = ".", cur_version = NULL) {
   }
 
   update_rextendr_version(path, cur_version = cur_version)
+  update_sys_reqs(path)
 
-  invisible(is_first)
+  invisible(TRUE)
 }
 
 update_rextendr_version <- function(path, cur_version = NULL) {
@@ -27,9 +28,29 @@ update_rextendr_version <- function(path, cur_version = NULL) {
       "You have {.str {cur}} but you need {.str {prev}}"
     ))
   } else if (!identical(cur, prev)) {
-    cli::cli_alert_info("Setting {.var Config/rextendr/version} to {.str {cur}}")
-    desc::desc_set(`Config/rextendr/version` = cur, file = path)
+    update_description("Config/rextendr/version", cur)
   }
+}
+
+update_sys_reqs <- function(path) {
+  cur <- "Cargo (rustc package manager)"
+  prev <- stringi::stri_trim_both(desc::desc_get("SystemRequirements", path)[[1]])
+
+  if (is.na(prev)) {
+    update_description("SystemRequirements", cur)
+  } else if (!identical(cur, prev)) {
+    cli::cli_ul(
+      c(
+        "The SystemRequirements field in the {.file DESCRIPTION} file is already set.",
+        "Please update it manually if needed."
+      )
+    )
+  }
+}
+
+update_description <- function(field, value) {
+  cli::cli_alert_info("Setting {.var {field}} to {.str {value}} in the {.file DESCRIPTION} file.")
+  desc::desc_set(field, value)
 }
 
 rextendr_version <- function(path = ".") {

--- a/R/use_extendr.R
+++ b/R/use_extendr.R
@@ -146,7 +146,6 @@ use_extendr <- function(path = ".",
     cli::cli_alert_success("Finished configuring {.pkg extendr} for package {.pkg {pkg_name}}.")
     cli::cli_ul(
       c(
-        "Please update the system requirement in {.file DESCRIPTION} file.",
         "Please run {.fun rextendr::document} for changes to take effect."
       )
     )

--- a/tests/testthat/_snaps/use_extendr.md
+++ b/tests/testthat/_snaps/use_extendr.md
@@ -4,7 +4,8 @@
       use_extendr()
     Message
       i First time using rextendr. Upgrading automatically...
-      i Setting `Config/rextendr/version` to "0.3.1.9000"
+      i Setting `Config/rextendr/version` to "0.3.1.9000" in the 'DESCRIPTION' file.
+      i Setting `SystemRequirements` to "Cargo (rustc package manager)" in the 'DESCRIPTION' file.
       v Creating 'src/rust/src'.
       v Writing 'src/entrypoint.c'
       v Writing 'src/Makevars'
@@ -17,7 +18,6 @@
       v Writing 'src/testpkg-win.def'
       v Writing 'R/extendr-wrappers.R'
       v Finished configuring extendr for package testpkg.
-      * Please update the system requirement in 'DESCRIPTION' file.
       * Please run `rextendr::document()` for changes to take effect.
 
 ---

--- a/tests/testthat/_snaps/use_extendr.md
+++ b/tests/testthat/_snaps/use_extendr.md
@@ -213,7 +213,6 @@
       > File 'src/testpkg.wrap-win.def' already exists. Skip writing the file.
       > File 'R/extendr-wrappers.R' already exists. Skip writing the file.
       v Finished configuring extendr for package testpkg.wrap.
-      * Please update the system requirement in 'DESCRIPTION' file.
       * Please run `rextendr::document()` for changes to take effect.
 
 # use_extendr() can overwrite files in non-interactive sessions
@@ -231,7 +230,6 @@
       v Writing 'src/testpkg-win.def'
       > File 'R/extendr-wrappers.R' already exists. Skip writing the file.
       v Finished configuring extendr for package testpkg.
-      * Please update the system requirement in 'DESCRIPTION' file.
       * Please run `rextendr::document()` for changes to take effect.
 
 ---

--- a/tests/testthat/test-use_extendr.R
+++ b/tests/testthat/test-use_extendr.R
@@ -8,7 +8,9 @@ test_that("use_extendr() sets up extendr files correctly", {
 
   # DESCRITION file
   version_in_desc <- stringi::stri_trim_both(desc::desc_get("Config/rextendr/version", path)[[1]])
+  sysreq_in_desc <- stringi::stri_trim_both(desc::desc_get("SystemRequirements", path)[[1]])
   expect_equal(version_in_desc, as.character(packageVersion("rextendr")))
+  expect_equal(sysreq_in_desc, "Cargo (rustc package manager)")
 
   # directory structure
   expect_true(dir.exists("src"))
@@ -45,7 +47,6 @@ test_that("use_extendr() does not set up packages with pre-existing src", {
 
   expect_false(created)
 })
-
 
 test_that("use_extendr() does not set up packages with pre-existing wrappers", {
   skip_if_not_installed("usethis")
@@ -150,4 +151,22 @@ test_that("R/ folder is created when not present", {
 
   # expect no error
   expect_rextendr_error(use_extendr(), regexp = NA)
+})
+
+test_that("Message if the SystemRequirements field is already set.", {
+  skip_if_not_installed("usethis")
+
+  path <- local_package("testpkg")
+  sys_req <- "testreq"
+
+  desc::desc_set("SystemRequirements", sys_req)
+
+  withr::local_options(usethis.quiet = FALSE)
+  expect_message(
+    created <- use_extendr(),
+    "Please update it manually if needed"
+  )
+
+  expect_true(created)
+  expect_equal(desc::desc_get("SystemRequirements")[[1]], sys_req)
 })


### PR DESCRIPTION
Currently a message to notice this field (`Please update the system requirement in 'DESCRIPTION' file.`), but I do not think there is any disadvantage to setting it up automatically.

The notation `SystemRequirements: Cargo (rustc package manager)` has been used in `gifski`, `hellorust` etc.
https://github.com/cran/gifski/blob/8bc440a1e3921af1f37a0deb27a01b8274d9b138/DESCRIPTION#L16
https://github.com/cran/hellorust/blob/2265950f01f2bbd87bab26c4f242b9fa8c9817dc/DESCRIPTION#L17