### PR TITLE
Skip tests with "long path" on Windows with R < 4.3

### DIFF
--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -94,3 +94,11 @@ skip_if_cargo_bin <- function(args = "--help") {
     }
   )
 }
+
+#' Helper function for skipping tests when the test possibly fails because of
+#' the path length limit. This only happens on R (<= 4.2) on Windows.
+skip_on_R42_win <- function() {
+  if (.Platform$OS.type == "windows" && getRversion() < "4.3") {
+    skip("Long path is not supported by this version of Rtools.")
+  }
+}

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -99,6 +99,6 @@ skip_if_cargo_bin <- function(args = "--help") {
 #' the path length limit. This only happens on R (<= 4.2) on Windows.
 skip_on_R42_win <- function() {
   if (.Platform$OS.type == "windows" && getRversion() < "4.3") {
-    skip("Long path is not supported by this version of Rtools.")
+    testthat::skip("Long path is not supported by this version of Rtools.")
   }
 }

--- a/tests/testthat/test-clean.R
+++ b/tests/testthat/test-clean.R
@@ -3,6 +3,7 @@ test_that("rextendr::clean() removes cargo target directory & binaries", {
   skip_if_not_installed("devtools")
   skip_on_cran()
   skip_if_cargo_bin()
+  skip_on_R42_win()
 
   path <- local_package("testpkg")
   use_extendr()

--- a/tests/testthat/test-optional-features.R
+++ b/tests/testthat/test-optional-features.R
@@ -1,7 +1,7 @@
 test_that("Feature 'ndarray' is enabled when no extra dependencies are specified", {
   skip_if_cargo_bin()
 
-  if (.Platform$OS.type == "windows" && getRversion() < '4.3') {
+  if (.Platform$OS.type == "windows" && getRversion() < "4.3") {
     skip("Long path is not supported by this version of Rtools.")
   }
 
@@ -21,7 +21,7 @@ test_that("Feature 'ndarray' is enabled when no extra dependencies are specified
 test_that("Feature 'ndarray' is enabled when 'extendr-api' has features enabled", {
   skip_if_cargo_bin()
 
-  if (.Platform$OS.type == "windows" && getRversion() < '4.3') {
+  if (.Platform$OS.type == "windows" && getRversion() < "4.3") {
     skip("Long path is not supported by this version of Rtools.")
   }
 

--- a/tests/testthat/test-optional-features.R
+++ b/tests/testthat/test-optional-features.R
@@ -1,6 +1,10 @@
 test_that("Feature 'ndarray' is enabled when no extra dependencies are specified", {
   skip_if_cargo_bin()
 
+  if (.Platform$OS.type == "windows" && getRversion() < '4.3') {
+    skip("Long path is not supported by this version of Rtools.")
+  }
+
   input <- file.path("../data/ndarray_example.rs")
   rust_source(
     file = input,
@@ -16,6 +20,10 @@ test_that("Feature 'ndarray' is enabled when no extra dependencies are specified
 
 test_that("Feature 'ndarray' is enabled when 'extendr-api' has features enabled", {
   skip_if_cargo_bin()
+
+  if (.Platform$OS.type == "windows" && getRversion() < '4.3') {
+    skip("Long path is not supported by this version of Rtools.")
+  }
 
   input <- file.path("../data/ndarray_example.rs")
   rust_source(

--- a/tests/testthat/test-optional-features.R
+++ b/tests/testthat/test-optional-features.R
@@ -1,9 +1,6 @@
 test_that("Feature 'ndarray' is enabled when no extra dependencies are specified", {
   skip_if_cargo_bin()
-
-  if (.Platform$OS.type == "windows" && getRversion() < "4.3") {
-    skip("Long path is not supported by this version of Rtools.")
-  }
+  skip_on_R42_win()
 
   input <- file.path("../data/ndarray_example.rs")
   rust_source(
@@ -20,10 +17,7 @@ test_that("Feature 'ndarray' is enabled when no extra dependencies are specified
 
 test_that("Feature 'ndarray' is enabled when 'extendr-api' has features enabled", {
   skip_if_cargo_bin()
-
-  if (.Platform$OS.type == "windows" && getRversion() < "4.3") {
-    skip("Long path is not supported by this version of Rtools.")
-  }
+  skip_on_R42_win()
 
   input <- file.path("../data/ndarray_example.rs")
   rust_source(


### PR DESCRIPTION
It seems Rust (>= 1.71) has deeper directory structure than before (1.70), and, in some cases, it seems to hit Windows' path limit. Since [long path is supported by Rtools 43 if the OS supports it](https://blog.r-project.org/2023/03/07/path-length-limit-on-windows/), we don't see such failures on R 4.3. This pull request disables these tests in question on R 4.2 on Windows.

https://github.com/extendr/extendr/pull/586#issuecomment-1637936087