### PR TITLE
feat(template): adds configure scripts

### DIFF
--- a/R/use_extendr.R
+++ b/R/use_extendr.R
@@ -69,6 +69,22 @@ use_extendr <- function(path = ".",
   }
 
   use_rextendr_template(
+    "configure",
+    save_as = file.path("configure"),
+    quiet = quiet,
+    as_executable = TRUE,
+    overwrite = overwrite
+  )
+
+  use_rextendr_template(
+    "configure.win",
+    save_as = file.path("configure.win"),
+    quiet = quiet,
+    as_executable = TRUE,
+    overwrite = overwrite
+  )
+
+  use_rextendr_template(
     "entrypoint.c",
     save_as = file.path("src", "entrypoint.c"),
     quiet = quiet,
@@ -211,6 +227,7 @@ throw_if_invalid_rust_name <- function(name, call = caller_env()) {
 #'
 #' @inheritParams usethis::use_template
 #' @inheritParams use_extendr
+#' @param as_executable Logical scalar indicating whether the file should be executable.
 #' @param overwrite Logical scalar or `NULL` indicating whether the file in the `path` should be overwritten.
 #' If `FALSE` and the file already exists, the function will do nothing.
 #' If `NULL` and the `usethis` package is installed, the function will ask the user whether the file should
@@ -221,6 +238,7 @@ use_rextendr_template <- function(template,
                                   save_as = template,
                                   data = list(),
                                   quiet = FALSE,
+                                  as_executable = FALSE,
                                   overwrite = NULL) {
   local_quiet_cli(quiet)
 
@@ -264,6 +282,10 @@ use_rextendr_template <- function(template,
     quiet = quiet,
     overwrite = overwrite
   )
+
+  if (isTRUE(as_executable)) {
+    Sys.chmod(save_as, mode = "755")
+  }
 
   invisible(TRUE)
 }

--- a/inst/templates/configure
+++ b/inst/templates/configure
@@ -1,0 +1,19 @@
+#!/usr/bin/env sh
+
+export PATH="$PATH:$HOME/.cargo/bin"
+
+if [ ! "$(command -v cargo)" ]; then
+    echo "----------------------- [RUST NOT FOUND]---------------------------"
+    echo "The 'cargo' command was not found on the PATH. Please install rustc"
+    echo "from: https://www.rust-lang.org/tools/install"
+    echo ""
+    echo "Alternatively, you may install cargo from your OS package manager:"
+    echo " - Debian/Ubuntu: apt-get install cargo"
+    echo " - Fedora/CentOS: dnf install cargo"
+    echo " - macOS: brew install rustc"
+    echo "-------------------------------------------------------------------"
+    echo ""
+    exit 1
+fi
+
+exit 0

--- a/inst/templates/configure.win
+++ b/inst/templates/configure.win
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+export PATH="$PATH:$HOME/.cargo/bin"
+
+if [ ! "$(command -v cargo)" ]; then
+    echo "----------------------- [RUST NOT FOUND]---------------------------"
+    echo "The 'cargo' command was not found on the PATH. Please install rustc"
+    echo "from: https://www.rust-lang.org/tools/install"
+    echo "-------------------------------------------------------------------"
+    echo ""
+    exit 1
+fi
+
+exit 0

--- a/tests/testthat/_snaps/use_extendr.md
+++ b/tests/testthat/_snaps/use_extendr.md
@@ -7,6 +7,8 @@
       i Setting `Config/rextendr/version` to "0.3.1.9000" in the 'DESCRIPTION' file.
       i Setting `SystemRequirements` to "Cargo (rustc package manager)" in the 'DESCRIPTION' file.
       v Creating 'src/rust/src'.
+      v Writing 'configure'
+      v Writing 'configure.win'
       v Writing 'src/entrypoint.c'
       v Writing 'src/Makevars'
       v Writing 'src/Makevars.win'
@@ -203,6 +205,8 @@
     Code
       use_extendr()
     Message
+      > File 'configure' already exists. Skip writing the file.
+      > File 'configure.win' already exists. Skip writing the file.
       > File 'src/entrypoint.c' already exists. Skip writing the file.
       > File 'src/Makevars' already exists. Skip writing the file.
       > File 'src/Makevars.win' already exists. Skip writing the file.
@@ -220,6 +224,8 @@
     Code
       use_extendr(crate_name = "foo", lib_name = "bar", overwrite = TRUE)
     Message
+      v Writing 'configure'
+      v Writing 'configure.win'
       v Writing 'src/entrypoint.c'
       v Writing 'src/Makevars'
       v Writing 'src/Makevars.win'


### PR DESCRIPTION
From <https://cran.r-project.org/web/packages/using_rust.html>

> The configure/configure.win script should check for the presence of commands cargo and rustc, and check their versions if required. This includes checking for system versions on the path and personal versions in ~/.cargo/bin (which are often not on the path). The Linux servers on the CRAN check farm use system versions, and Linux distributions are often slow to update these so version requirements need to be conservative.

configure scripts are copied from prqlr 0.5.0