### PR TITLE
fix: use the CRAN suggesting `SystemRequirements` field

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # rextendr (development version)
 
 * `use_extendr()` and `document()` now set the `SystemRequirements` field of the `DESCRIPTION` file to
-  `Cargo (rustc package manager)` if the field is empty (#298).
+  `Cargo (Rust's package manager), rustc` if the field is empty (#298, #310).
 * `use_extendr()` gets a new ability to overwrite existing rextendr templates (#292).
 * `use_extendr()` sets `publish = false` in the `[package]` section of the `Cargo.toml` (#297).
 

--- a/R/setup.R
+++ b/R/setup.R
@@ -33,7 +33,7 @@ update_rextendr_version <- function(path, cur_version = NULL) {
 }
 
 update_sys_reqs <- function(path) {
-  cur <- "Cargo (rustc package manager)"
+  cur <- "Cargo (Rust's package manager), rustc"
   prev <- stringi::stri_trim_both(desc::desc_get("SystemRequirements", path)[[1]])
 
   if (is.na(prev)) {

--- a/tests/testthat/_snaps/use_extendr.md
+++ b/tests/testthat/_snaps/use_extendr.md
@@ -5,7 +5,7 @@
     Message
       i First time using rextendr. Upgrading automatically...
       i Setting `Config/rextendr/version` to "0.3.1.9000" in the 'DESCRIPTION' file.
-      i Setting `SystemRequirements` to "Cargo (rustc package manager)" in the 'DESCRIPTION' file.
+      i Setting `SystemRequirements` to "Cargo (Rust's package manager), rustc" in the 'DESCRIPTION' file.
       v Creating 'src/rust/src'.
       v Writing 'src/entrypoint.c'
       v Writing 'src/Makevars'

--- a/tests/testthat/test-use_extendr.R
+++ b/tests/testthat/test-use_extendr.R
@@ -10,7 +10,7 @@ test_that("use_extendr() sets up extendr files correctly", {
   version_in_desc <- stringi::stri_trim_both(desc::desc_get("Config/rextendr/version", path)[[1]])
   sysreq_in_desc <- stringi::stri_trim_both(desc::desc_get("SystemRequirements", path)[[1]])
   expect_equal(version_in_desc, as.character(packageVersion("rextendr")))
-  expect_equal(sysreq_in_desc, "Cargo (rustc package manager)")
+  expect_equal(sysreq_in_desc, "Cargo (Rust's package manager), rustc")
 
   # directory structure
   expect_true(dir.exists("src"))


### PR DESCRIPTION
From <https://cran.r-project.org/web/packages/using_rust.html>

> The package should declare
> SystemRequirements: Cargo (Rust's package manager), rustc