### PR TITLE
fix(template): set `CARGO_BUILD_JOBS=2` on CRAN

### DIFF
--- a/inst/templates/Makevars
+++ b/inst/templates/Makevars
@@ -15,6 +15,7 @@ $(STATLIB):
 	# therefore is only used if cargo is absent from the user's PATH.
 	if [ "$(NOT_CRAN)" != "true" ]; then \
 		export CARGO_HOME=$(CARGOTMP); \
+		export CARGO_BUILD_JOBS=2; \
 	fi && \
 		export PATH="$(PATH):$(HOME)/.cargo/bin" && \
 		cargo build --lib --release --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)

--- a/inst/templates/Makevars.win
+++ b/inst/templates/Makevars.win
@@ -24,6 +24,7 @@ $(STATLIB):
 	# CARGO_LINKER is provided in Makevars.ucrt for R >= 4.2
 	if [ "$(NOT_CRAN)" != "true" ]; then \
 		export CARGO_HOME=$(CARGOTMP); \
+		export CARGO_BUILD_JOBS=2; \
 	fi && \
 		export CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER="$(CARGO_LINKER)" && \
 		export LIBRARY_PATH="$${LIBRARY_PATH};$(CURDIR)/$(TARGET_DIR)/libgcc_mock" && \

--- a/tests/testthat/_snaps/use_extendr.md
+++ b/tests/testthat/_snaps/use_extendr.md
@@ -60,6 +60,7 @@
       	# therefore is only used if cargo is absent from the user's PATH.
       	if [ "$(NOT_CRAN)" != "true" ]; then \
       		export CARGO_HOME=$(CARGOTMP); \
+      		export CARGO_BUILD_JOBS=2; \
       	fi && \
       		export PATH="$(PATH):$(HOME)/.cargo/bin" && \
       		cargo build --lib --release --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
@@ -105,6 +106,7 @@
       	# CARGO_LINKER is provided in Makevars.ucrt for R >= 4.2
       	if [ "$(NOT_CRAN)" != "true" ]; then \
       		export CARGO_HOME=$(CARGOTMP); \
+      		export CARGO_BUILD_JOBS=2; \
       	fi && \
       		export CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER="$(CARGO_LINKER)" && \
       		export LIBRARY_PATH="$${LIBRARY_PATH};$(CURDIR)/$(TARGET_DIR)/libgcc_mock" && \
@@ -272,6 +274,7 @@
       	# therefore is only used if cargo is absent from the user's PATH.
       	if [ "$(NOT_CRAN)" != "true" ]; then \
       		export CARGO_HOME=$(CARGOTMP); \
+      		export CARGO_BUILD_JOBS=2; \
       	fi && \
       		export PATH="$(PATH):$(HOME)/.cargo/bin" && \
       		cargo build --lib --release --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)


### PR DESCRIPTION
The CRAN policy limits the number of cores that can be used during installation to 2.

From <https://cran.r-project.org/web/packages/policies.html>

> Checking the package should take as little CPU time as possible, as the CRAN check farm is a very limited resource and there are thousands of packages. Long-running tests and vignette code can be made optional for checking, but do ensure that the checks that are left do exercise all the features of the package.
>
> If running a package uses multiple threads/cores it must never use more than two simultaneously: the check farm is a shared resource and will typically be running many checks simultaneously. 

From <https://cran.r-project.org/web/packages/using_rust.html>

> cargo build -j N defaults to the number of ‘logical CPUs’. This usually exceeds the maximum allowed in the CRAN policy, so needs to be set explicitly to N=1 or 2.