### PR TITLE
[Bugfix] Correctly handle `use_extendr(custom_path)`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
   `Cargo (rustc package manager)` if the field is empty (#298).
 * `use_extendr()` gets a new ability to overwrite existing rextendr templates (#292).
 * `use_extendr()` sets `publish = false` in the `[package]` section of the `Cargo.toml` (#297).
+* `use_extendr()` correctly handles calls with `path` not equal to  `"."` (current folder), or when there is no active `{usethis}` project (#323).
 
 # rextend 0.3.1
 

--- a/R/setup.R
+++ b/R/setup.R
@@ -1,26 +1,27 @@
 rextendr_setup <- function(path = ".", cur_version = NULL) {
-  if (!file.exists(file.path(path, "DESCRIPTION"))) {
+  desc_path <- rprojroot::find_package_root_file("DESCRIPTION", path = path)
+  if (!file.exists(desc_path)) {
     cli::cli_abort(
       "{.arg path} ({.path {path}}) does not contain a DESCRIPTION",
       class = "rextendr_error"
     )
   }
 
-  is_first <- is.na(rextendr_version(path))
+  is_first <- is.na(rextendr_version(desc_path = desc_path))
 
   if (is_first) {
     cli::cli_alert_info("First time using rextendr. Upgrading automatically...")
   }
 
-  update_rextendr_version(path, cur_version = cur_version)
-  update_sys_reqs(path)
+  update_rextendr_version(desc_path = desc_path, cur_version = cur_version)
+  update_sys_reqs(desc_path = desc_path)
 
   invisible(TRUE)
 }
 
-update_rextendr_version <- function(path, cur_version = NULL) {
+update_rextendr_version <- function(desc_path, cur_version = NULL) {
   cur <- cur_version %||% as.character(utils::packageVersion("rextendr"))
-  prev <- rextendr_version(path)
+  prev <- rextendr_version(desc_path = desc_path)
 
   if (!is.na(cur) && !is.na(prev) && package_version(cur) < package_version(prev)) {
     cli::cli_alert_warning(c(
@@ -28,16 +29,16 @@ update_rextendr_version <- function(path, cur_version = NULL) {
       "You have {.str {cur}} but you need {.str {prev}}"
     ))
   } else if (!identical(cur, prev)) {
-    update_description("Config/rextendr/version", cur)
+    update_description("Config/rextendr/version", cur, desc_path = desc_path)
   }
 }
 
-update_sys_reqs <- function(path) {
+update_sys_reqs <- function(desc_path) {
   cur <- "Cargo (rustc package manager)"
-  prev <- stringi::stri_trim_both(desc::desc_get("SystemRequirements", path)[[1]])
+  prev <- stringi::stri_trim_both(desc::desc_get("SystemRequirements", file = desc_path)[[1]])
 
   if (is.na(prev)) {
-    update_description("SystemRequirements", cur)
+    update_description("SystemRequirements", cur, desc_path = desc_path)
   } else if (!identical(cur, prev)) {
     cli::cli_ul(
       c(
@@ -48,11 +49,11 @@ update_sys_reqs <- function(path) {
   }
 }
 
-update_description <- function(field, value) {
+update_description <- function(field, value, desc_path) {
   cli::cli_alert_info("Setting {.var {field}} to {.str {value}} in the {.file DESCRIPTION} file.")
-  desc::desc_set(field, value)
+  desc::desc_set(field, value, file = desc_path)
 }
 
-rextendr_version <- function(path = ".") {
-  stringi::stri_trim_both(desc::desc_get("Config/rextendr/version", path)[[1]])
+rextendr_version <- function(desc_path = ".") {
+  stringi::stri_trim_both(desc::desc_get("Config/rextendr/version", desc_path)[[1]])
 }

--- a/R/use_extendr.R
+++ b/R/use_extendr.R
@@ -39,7 +39,11 @@ use_extendr <- function(path = ".",
 
   rextendr_setup(path = path)
 
-  pkg_name <- pkg_name(path)
+  if (isFALSE(path == ".")) {
+    usethis::local_project(path, quiet = quiet)
+  }
+
+  pkg_name <- pkg_name()
   mod_name <- as_valid_rust_name(pkg_name)
 
   if (is.null(crate_name)) {
@@ -54,8 +58,9 @@ use_extendr <- function(path = ".",
     throw_if_invalid_rust_name(lib_name)
   }
 
-  src_dir <- rprojroot::find_package_root_file("src", path = path)
-  r_dir <- rprojroot::find_package_root_file("R", path = path)
+  src_dir <- rprojroot::find_package_root_file("src")
+  r_dir <- rprojroot::find_package_root_file("R")
+
 
   if (!dir.exists(r_dir)) {
     dir.create(r_dir)

--- a/R/use_extendr.R
+++ b/R/use_extendr.R
@@ -39,7 +39,10 @@ use_extendr <- function(path = ".",
 
   rextendr_setup(path = path)
 
-  if (isFALSE(path == ".")) {
+  root_path <- normalizePath(rprojroot::find_package_root_file(path = path), mustWork = FALSE, winslash = "/")
+  usethis_proj_path <- try_get_proj_path()
+
+  if (!isTRUE(root_path == usethis_proj_path)) {
     usethis::local_project(path, quiet = quiet)
   }
 
@@ -163,6 +166,10 @@ use_extendr <- function(path = ".",
   }
 
   return(invisible(TRUE))
+}
+
+try_get_proj_path <- function() {
+  tryCatch(usethis::proj_get(), error = function(e) NA)
 }
 
 #' Checks if provided name is a valid Rust name (identifier)

--- a/tests/testthat/test-use_extendr.R
+++ b/tests/testthat/test-use_extendr.R
@@ -175,3 +175,12 @@ test_that("Message if the SystemRequirements field is already set.", {
   expect_true(created)
   expect_equal(desc::desc_get("SystemRequirements")[[1]], sys_req)
 })
+
+test_that("`use_extendr()` works correctly when path is specified explicitly", {
+  skip_if_not_installed("usethis")
+  local_temp_dir("temp_dir")
+  usethis::create_package("testpkg")
+
+  use_extendr(path = "testpkg")
+  succeed()
+})

--- a/tests/testthat/test-use_extendr_with_path.R
+++ b/tests/testthat/test-use_extendr_with_path.R
@@ -1,0 +1,8 @@
+test_that("`use_extendr()` works correctly when path is specified explicitly", {
+  skip_if_not_installed("usethis")
+  local_temp_dir("temp_dir")
+  usethis::create_package("testpkg")
+
+  use_extendr(path = "testpkg")
+  succeed()
+})

--- a/tests/testthat/test-use_extendr_with_path.R
+++ b/tests/testthat/test-use_extendr_with_path.R
@@ -1,8 +1,0 @@
-test_that("`use_extendr()` works correctly when path is specified explicitly", {
-  skip_if_not_installed("usethis")
-  local_temp_dir("temp_dir")
-  usethis::create_package("testpkg")
-
-  use_extendr(path = "testpkg")
-  succeed()
-})


### PR DESCRIPTION
Correctly handle situations when `use_extendr()` is called with a non-default path. Now it temporarily sets the working directory and `{usthis}` path to the package root.