### PR TITLE
update SystemRequirements to match CRAN requirements

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # rextendr (development version)
 
+* `use_extendr()` sets the `DESCRIPTION`'s `SystemRequirements` field according to CRAN policy to `Cargo (Rust's package manager), rustc` (#329)
 * Introduces new functions `use_cran_defaults()` and `vendor_pkgs()` to ease the publication of extendr-powered packages on CRAN. See the new article _CRAN compliant extendr packages_ on how to use these (#320).
 * `rust_sitrep()` now better communicates the status of the Rust toolchain and available targets. It also guides the user through necessary installation steps to fix Rust setup (#318).
 * `use_extendr()` and `document()` now set the `SystemRequirements` field of the `DESCRIPTION` file to

--- a/R/setup.R
+++ b/R/setup.R
@@ -34,7 +34,7 @@ update_rextendr_version <- function(desc_path, cur_version = NULL) {
 }
 
 update_sys_reqs <- function(desc_path) {
-  cur <- "Cargo (rustc package manager)"
+  cur <- "Cargo (Rust's package manager), rustc"
   prev <- stringi::stri_trim_both(desc::desc_get("SystemRequirements", file = desc_path)[[1]])
 
   if (is.na(prev)) {

--- a/tests/testthat/_snaps/use_cran_defaults.md
+++ b/tests/testthat/_snaps/use_cran_defaults.md
@@ -5,7 +5,7 @@
     Message
       i First time using rextendr. Upgrading automatically...
       i Setting `Config/rextendr/version` to "0.3.1.9000" in the 'DESCRIPTION' file.
-      i Setting `SystemRequirements` to "Cargo (rustc package manager)" in the 'DESCRIPTION' file.
+      i Setting `SystemRequirements` to "Cargo (Rust's package manager), rustc" in the 'DESCRIPTION' file.
       v Creating 'src/rust/src'.
       v Writing 'src/entrypoint.c'
       v Writing 'src/Makevars'

--- a/tests/testthat/_snaps/use_extendr.md
+++ b/tests/testthat/_snaps/use_extendr.md
@@ -5,7 +5,7 @@
     Message
       i First time using rextendr. Upgrading automatically...
       i Setting `Config/rextendr/version` to "0.3.1.9000" in the 'DESCRIPTION' file.
-      i Setting `SystemRequirements` to "Cargo (rustc package manager)" in the 'DESCRIPTION' file.
+      i Setting `SystemRequirements` to "Cargo (Rust's package manager), rustc" in the 'DESCRIPTION' file.
       v Creating 'src/rust/src'.
       v Writing 'src/entrypoint.c'
       v Writing 'src/Makevars'

--- a/tests/testthat/test-use_extendr.R
+++ b/tests/testthat/test-use_extendr.R
@@ -10,7 +10,7 @@ test_that("use_extendr() sets up extendr files correctly", {
   version_in_desc <- stringi::stri_trim_both(desc::desc_get("Config/rextendr/version", path)[[1]])
   sysreq_in_desc <- stringi::stri_trim_both(desc::desc_get("SystemRequirements", path)[[1]])
   expect_equal(version_in_desc, as.character(packageVersion("rextendr")))
-  expect_equal(sysreq_in_desc, "Cargo (rustc package manager)")
+  expect_equal(sysreq_in_desc, "Cargo (Rust's package manager), rustc")
 
   # directory structure
   expect_true(dir.exists("src"))


### PR DESCRIPTION
This PR is a follow up of #320 and a replication of #310 

In order for #320 to be successful the `SystemRequirements` field needs to match the CRAN requirement. This PR adjusts the field accordingly and updates the requisite tests. 