### PR TITLE
update R CMD check to use binaries

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -54,6 +54,7 @@ jobs:
         with:
           cache-version: 2
           extra-packages: rcmdcheck
+          use-public-rspm: true
 
       # TODO: allow warnings on oldrel (cf., https://stat.ethz.ch/pipermail/r-package-devel/2023q2/009229.html)
       - name: Check R version


### PR DESCRIPTION
This PR adds a change to the R CMD check github action to use linux binaries from P3M (posit public package manager formerly RSPM) https://p3m.dev/client/#/

This should significantly reduce check CI time. 