### PR TITLE
add empty workspace 

### DIFF
--- a/R/use_extendr.R
+++ b/R/use_extendr.R
@@ -135,6 +135,7 @@ use_extendr <- function(path = ".",
 
   edition <- match.arg(edition, several.ok = FALSE)
   cargo_toml_content <- to_toml(
+    workspace = list(),
     package = list(name = crate_name, publish = FALSE, version = "0.1.0", edition = edition),
     lib = list(`crate-type` = array("staticlib", 1), name = lib_name),
     dependencies = list(`extendr-api` = "*")


### PR DESCRIPTION
This ensures the output dir match the one defined in Makevars.

```
.
├── Cargo.toml
├── LICENSE
├── README.md
├── rmin
│  ├── build.rs
│  ├── Cargo.toml
│  └── src
│     ├── base.no-std.rs
│     ├── base.no-std.unwind.rs
│     ├── base.rs
│     ├── base.s.r-type.lib-r.rs
│     ├── base.s.r-type.rs
│     ├── base.s.rs
│     └── lib.rs
├── rmin-eh
│  ├── Cargo.toml
│  └── src
│     ├── dwarf
│     ├── emcc.rs
│     ├── gcc.rs
│     └── lib.rs
├── rmin-examples
│  ├── Cargo.toml
│  ├── R-package-demo
│  │  └── rext
│  └── src
│     ├── compare-rextendr.rs.txt
│     └── lib.rs
└── rmin-macros
   ├── Cargo.toml
   └── src
      └── lib.rs
```
Suppose I'm writting something under a workspace (see the structure above).

The `Cargo.toml` in the root contains a `[workspace]` unit, and thus all the inner `Cargo.toml` file is affected.

As for the `rmin-examples/R-package-demo/rext/src/rust` crate, It is affected and thus may failed to compile:
```
$ cargo build
error: current package believes it's in a workspace when it's not:
current:   /me/rmin/rmin-examples/R-package-demo/rext/src/rust/Cargo.toml
workspace: /me/rmin/Cargo.toml

this may be fixable by adding `rmin-examples/R-package-demo/rext/src/rust` to the `workspace.members` array of the manifest located at: /me/rmin/Cargo.toml
Alternatively, to keep it out of the workspace, add the package to the `workspace.exclude` array, or add an empty `[workspace]` table to the package's manifest.
```

As it suggests, adding an empty `[workspace]` solve this problem, this is the reason why I open this PR.