### PR TITLE
[CI]: Remove `pandoc` 

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -34,8 +34,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: r-lib/actions/setup-pandoc@v2
-
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.config.rust-version }}

--- a/.github/workflows/test_pkg_gen.yaml
+++ b/.github/workflows/test_pkg_gen.yaml
@@ -50,9 +50,6 @@ jobs:
           # TODO: enable RSPM when all the packages are available
           use-public-rspm: false
 
-      - name: Set up pandoc
-        uses: r-lib/actions/setup-pandoc@v2
-
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           # increment this version number when we need to clear the cache


### PR DESCRIPTION
Proof of Concept: Do we need `pandoc` in the CI scripts?

Update: Turns out, installing `pandoc` is not necessary for the CI scripts. I vote for this to removed to ease the running time overall.

Cheers