### PR TITLE
Address extendr-api CI failures

### DIFF
--- a/R/use_extendr.R
+++ b/R/use_extendr.R
@@ -137,7 +137,8 @@ use_extendr <- function(path = ".",
   cargo_toml_content <- to_toml(
     package = list(name = crate_name, publish = FALSE, version = "0.1.0", edition = edition),
     lib = list(`crate-type` = array("staticlib", 1), name = lib_name),
-    dependencies = list(`extendr-api` = "*")
+    dependencies = list(`extendr-api` = list(git = "https://github.com/extendr/extendr"))
+    # dependencies = list(`extendr-api` = "*")
   )
 
   use_rextendr_template(

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -25,7 +25,8 @@
 
     # Version of 'extendr_api' to be used
     rextendr.extendr_deps = list(
-      `extendr-api` = "*"
+      # `extendr-api` = "*"
+      `extendr-api` = list(git = "https://github.com/extendr/extendr")
     ),
     rextendr.extendr_dev_deps = list(
       `extendr-api` = list(git = "https://github.com/extendr/extendr")

--- a/tests/testthat/_snaps/use_cran_defaults.md
+++ b/tests/testthat/_snaps/use_cran_defaults.md
@@ -12,7 +12,7 @@
       v Writing 'src/Makevars.win'
       v Writing 'src/Makevars.ucrt'
       v Writing 'src/.gitignore'
-      v Adding "^src/\\.cargo$" to '.Rbuildignore'.
+      v Adding '^src/\\.cargo$' to '.Rbuildignore'
       v Writing 'src/rust/Cargo.toml'
       v Writing 'src/rust/src/lib.rs'
       v Writing 'src/testpkg-win.def'
@@ -29,8 +29,8 @@
       v Writing 'configure.win'
       > File 'src/Makevars' already exists. Skip writing the file.
       > File 'src/Makevars.win' already exists. Skip writing the file.
-      v Adding "^src/rust/vendor$" to '.Rbuildignore'.
-      v Adding "src/rust/vendor" to '.gitignore'.
+      v Adding '^src/rust/vendor$' to '.Rbuildignore'
+      v Adding 'src/rust/vendor' to '.gitignore'
 
 ---
 
@@ -173,6 +173,10 @@
       cat_file("src", "rust", "vendor-config.toml")
     Output
       [source.crates-io]
+      replace-with = "vendored-sources"
+      
+      [source."git+https://github.com/extendr/extendr"]
+      git = "https://github.com/extendr/extendr"
       replace-with = "vendored-sources"
       
       [source.vendored-sources]

--- a/tests/testthat/_snaps/use_extendr.md
+++ b/tests/testthat/_snaps/use_extendr.md
@@ -12,7 +12,7 @@
       v Writing 'src/Makevars.win'
       v Writing 'src/Makevars.ucrt'
       v Writing 'src/.gitignore'
-      v Adding "^src/\\.cargo$" to '.Rbuildignore'.
+      v Adding '^src/\\.cargo$' to '.Rbuildignore'
       v Writing 'src/rust/Cargo.toml'
       v Writing 'src/rust/src/lib.rs'
       v Writing 'src/testpkg-win.def'
@@ -169,7 +169,7 @@
       name = 'testpkg'
       
       [dependencies]
-      extendr-api = '*'
+      extendr-api = { git = 'https://github.com/extendr/extendr' }
 
 ---
 
@@ -248,7 +248,7 @@
       name = 'bar'
       
       [dependencies]
-      extendr-api = '*'
+      extendr-api = { git = 'https://github.com/extendr/extendr' }
 
 # use_rextendr_template() can overwrite existing files
 

--- a/tests/testthat/test-optional-features.R
+++ b/tests/testthat/test-optional-features.R
@@ -23,7 +23,7 @@ test_that("Feature 'ndarray' is enabled when 'extendr-api' has features enabled"
   rust_source(
     file = input,
     features = "ndarray",
-    extendr_deps = list(`extendr-api` = list(version = "*", features = array("serde")))
+    extendr_deps = list(`extendr-api` = list(git = "https://github.com/extendr/extendr", features = array("serde")))
   )
 
   data <- matrix(runif(100L), 25)


### PR DESCRIPTION
This PR addresses the failing CI tests in https://github.com/extendr/extendr/pull/842.

It does so by using the current head of the git repository for CI instead of the currently released version on crates.io. 

This also updates snapshots to pass the tests.

This should let us pass CI on extendr-api and prove that we can also patch extendr-api to keep up with the changes in libR-sys due to non-API. 

The question is: do we want to keep rextendr testing main? Or revert the change after being merged?

