### PR TITLE
re-ordered steps in CRAN template

### DIFF
--- a/inst/templates/Makevars
+++ b/inst/templates/Makevars
@@ -17,7 +17,6 @@ $(STATLIB):
 		export CARGO_HOME=$(CARGOTMP); \
 	fi && \
 		export PATH="$(PATH):$(HOME)/.cargo/bin" && \
-            echo `cargo --version` && echo `rustc --version` && \
             cargo build --lib --release --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR);
 	if [ "$(NOT_CRAN)" != "true" ]; then \
 		rm -Rf $(CARGOTMP) && \

--- a/inst/templates/Makevars
+++ b/inst/templates/Makevars
@@ -17,7 +17,8 @@ $(STATLIB):
 		export CARGO_HOME=$(CARGOTMP); \
 	fi && \
 		export PATH="$(PATH):$(HOME)/.cargo/bin" && \
-		cargo build --lib --release --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
+            echo `cargo --version` && echo `rustc --version` && \
+            cargo build --lib --release --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR);
 	if [ "$(NOT_CRAN)" != "true" ]; then \
 		rm -Rf $(CARGOTMP) && \
 		rm -Rf $(LIBDIR)/build; \

--- a/inst/templates/Makevars.win
+++ b/inst/templates/Makevars.win
@@ -27,7 +27,6 @@ $(STATLIB):
 	fi && \
 		export CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER="$(CARGO_LINKER)" && \
 		export LIBRARY_PATH="$${LIBRARY_PATH};$(CURDIR)/$(TARGET_DIR)/libgcc_mock" && \
-		echo `cargo --version` && echo `rustc --version` && \
 		cargo build --target=$(TARGET) --lib --release --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR);
 	if [ "$(NOT_CRAN)" != "true" ]; then \
 		rm -Rf $(CARGOTMP) && \

--- a/inst/templates/Makevars.win
+++ b/inst/templates/Makevars.win
@@ -27,7 +27,8 @@ $(STATLIB):
 	fi && \
 		export CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER="$(CARGO_LINKER)" && \
 		export LIBRARY_PATH="$${LIBRARY_PATH};$(CURDIR)/$(TARGET_DIR)/libgcc_mock" && \
-		cargo build --target=$(TARGET) --lib --release --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
+		echo `cargo --version` && echo `rustc --version` && \
+		cargo build --target=$(TARGET) --lib --release --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR);
 	if [ "$(NOT_CRAN)" != "true" ]; then \
 		rm -Rf $(CARGOTMP) && \
 		rm -Rf $(LIBDIR)/build; \

--- a/inst/templates/cran/Makevars
+++ b/inst/templates/cran/Makevars
@@ -24,9 +24,9 @@ $(STATLIB):
 	if [ "$(NOT_CRAN)" != "true" ]; then \
 		export CARGO_HOME=$(CARGOTMP); \
 	fi && \
-		export PATH="$(PATH):$(HOME)/.cargo/bin" && \
-			cargo build $(CRAN_FLAGS) --lib --release --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR) && \
-			echo `cargo --version` && echo `rustc --version`;
+        echo `cargo --version` && echo `rustc --version` && \
+            export PATH="$(PATH):$(HOME)/.cargo/bin" && \
+			cargo build $(CRAN_FLAGS) --lib --release --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR);
 		rm -Rf $(CARGOTMP) $(VENDOR_DIR) $(LIBDIR)/build; \
 
 C_clean:

--- a/inst/templates/cran/Makevars
+++ b/inst/templates/cran/Makevars
@@ -24,8 +24,8 @@ $(STATLIB):
 	if [ "$(NOT_CRAN)" != "true" ]; then \
 		export CARGO_HOME=$(CARGOTMP); \
 	fi && \
-        echo `cargo --version` && echo `rustc --version` && \
-            export PATH="$(PATH):$(HOME)/.cargo/bin" && \
+        export PATH="$(PATH):$(HOME)/.cargo/bin" && \
+            echo `cargo --version` && echo `rustc --version` && \
 			cargo build $(CRAN_FLAGS) --lib --release --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR);
 		rm -Rf $(CARGOTMP) $(VENDOR_DIR) $(LIBDIR)/build; \
 

--- a/inst/templates/cran/Makevars
+++ b/inst/templates/cran/Makevars
@@ -25,7 +25,6 @@ $(STATLIB):
 		export CARGO_HOME=$(CARGOTMP); \
 	fi && \
         export PATH="$(PATH):$(HOME)/.cargo/bin" && \
-            echo `cargo --version` && echo `rustc --version` && \
 			cargo build $(CRAN_FLAGS) --lib --release --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR);
 		rm -Rf $(CARGOTMP) $(VENDOR_DIR) $(LIBDIR)/build; \
 

--- a/inst/templates/cran/Makevars.win
+++ b/inst/templates/cran/Makevars.win
@@ -33,10 +33,10 @@ $(STATLIB):
 	if [ "$(NOT_CRAN)" != "true" ]; then \
 		export CARGO_HOME=$(CARGOTMP); \
 	fi && \
+		echo `cargo --version` && echo `rustc --version` && \
 		export CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER="$(CARGO_LINKER)" && \
 		export LIBRARY_PATH="$${LIBRARY_PATH};$(CURDIR)/$(TARGET_DIR)/libgcc_mock"; \
-		cargo build $(CRAN_FLAGS) --target=$(TARGET) --lib --release --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR) && \
-		echo `cargo --version` && echo `rustc --version`;
+		cargo build $(CRAN_FLAGS) --target=$(TARGET) --lib --release --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR);
 	if [ "$(NOT_CRAN)" != "true" ]; then \
 		rm -Rf $(CARGOTMP) $(VENDOR_DIR) $(LIBDIR)/build; \
 	fi

--- a/inst/templates/cran/Makevars.win
+++ b/inst/templates/cran/Makevars.win
@@ -35,7 +35,6 @@ $(STATLIB):
 	fi && \
     export CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER="$(CARGO_LINKER)" && \
 		export LIBRARY_PATH="$${LIBRARY_PATH};$(CURDIR)/$(TARGET_DIR)/libgcc_mock"; \
-		echo `cargo --version` && echo `rustc --version` && \
 		cargo build $(CRAN_FLAGS) --target=$(TARGET) --lib --release --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR);
 	if [ "$(NOT_CRAN)" != "true" ]; then \
 		rm -Rf $(CARGOTMP) $(VENDOR_DIR) $(LIBDIR)/build; \

--- a/inst/templates/cran/Makevars.win
+++ b/inst/templates/cran/Makevars.win
@@ -33,9 +33,9 @@ $(STATLIB):
 	if [ "$(NOT_CRAN)" != "true" ]; then \
 		export CARGO_HOME=$(CARGOTMP); \
 	fi && \
-		echo `cargo --version` && echo `rustc --version` && \
-		export CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER="$(CARGO_LINKER)" && \
+    export CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER="$(CARGO_LINKER)" && \
 		export LIBRARY_PATH="$${LIBRARY_PATH};$(CURDIR)/$(TARGET_DIR)/libgcc_mock"; \
+		echo `cargo --version` && echo `rustc --version` && \
 		cargo build $(CRAN_FLAGS) --target=$(TARGET) --lib --release --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR);
 	if [ "$(NOT_CRAN)" != "true" ]; then \
 		rm -Rf $(CARGOTMP) $(VENDOR_DIR) $(LIBDIR)/build; \


### PR DESCRIPTION
Hi all, 

The new version of R CMD check now tests whether the rustc version is reported *before* any rust code is compiled (the new R CMD check source code is linked [here](https://github.com/wch/r-source/blob/3e6b6042d2714566b8974204bf7ffa5c3a15ee5f/src/library/tools/R/check.R#L3953)). 

As it stands the rextendr templates report the rustc and cargo version *after* the code is compiled, which does not pass the new tests.  This PR switches two lines in the Makevars files so that the code first reports the rustc version, and then compiles the rust code. 

I have used this change to successfully update my package, [zoomerjoin](https://cran.r-project.org/web/packages/zoomerjoin/index.html) so it passes the new CRAN tests, but the changes haven't fully propagated through to the CRAN package page yet.  I will update the PR immediately if there end up being any issues with this approach. 

Best,  
Ben 