### PR TITLE
Add `--print=native-static-libs` when compiling 

### DIFF
--- a/.github/workflows/test_pkg_gen.yaml
+++ b/.github/workflows/test_pkg_gen.yaml
@@ -85,17 +85,6 @@ jobs:
             file.path("tests", "testthat", "test-hello.R")
           )
 
-          # test NOT_CRAN envvar
-          brio::write_lines(
-            c(
-              "if [ \"$NOT_CRAN\" != \"true\" ]; then",
-              "  exit 1",
-              "fi"
-            ),
-            file.path("configure")
-          )
-          Sys.chmod("configure", "0755")
-
           # TODO: allow warnings on oldrel (cf., https://stat.ethz.ch/pipermail/r-package-devel/2023q2/009229.html)
           if (.Platform$OS.type == "windows" && getRversion() < "4.3.0") {
             error_on <- "error"

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # rextendr (development version)
 
+* `Makevars` now prints linked static libraries at compile time
 * `use_extendr()` sets the `DESCRIPTION`'s `SystemRequirements` field according to CRAN policy to `Cargo (Rust's package manager), rustc` (#329)
 * Introduces new functions `use_cran_defaults()` and `vendor_pkgs()` to ease the publication of extendr-powered packages on CRAN. See the new article _CRAN compliant extendr packages_ on how to use these (#320).
 * `rust_sitrep()` now better communicates the status of the Rust toolchain and available targets. It also guides the user through necessary installation steps to fix Rust setup (#318).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # rextendr (development version)
 
-* `Makevars` now prints linked static libraries at compile time
+* `Makevars` now prints linked static libraries at compile time <https://github.com/extendr/rextendr/pull/393>
 * `use_extendr()` sets the `DESCRIPTION`'s `SystemRequirements` field according to CRAN policy to `Cargo (Rust's package manager), rustc` (#329)
 * Introduces new functions `use_cran_defaults()` and `vendor_pkgs()` to ease the publication of extendr-powered packages on CRAN. See the new article _CRAN compliant extendr packages_ on how to use these (#320).
 * `rust_sitrep()` now better communicates the status of the Rust toolchain and available targets. It also guides the user through necessary installation steps to fix Rust setup (#318).

--- a/R/cran-compliance.R
+++ b/R/cran-compliance.R
@@ -52,42 +52,6 @@ use_cran_defaults <- function(path = ".", quiet = FALSE, overwrite = NULL, lib_n
     )
   }
 
-  # create tools directory if it does not exist
-  if (!dir.exists("tools")) {
-    dir.create("tools")
-  }
-
-  # add msrv.R template
-  use_rextendr_template(
-    "cran/msrv.R",
-    save_as = file.path("tools", "msrv.R"),
-    quiet = quiet,
-    overwrite = overwrite
-  )
-
-  # add configure and configure.win templates
-  use_rextendr_template(
-    "cran/configure",
-    save_as = "configure",
-    quiet = quiet,
-    overwrite = overwrite,
-    data = list(lib_name = lib_name)
-  )
-
-  # configure needs to be made executable
-  # ignore for Windows
-  if (.Platform[["OS.type"]] == "unix") {
-    Sys.chmod("configure", "0755")
-  }
-
-  use_rextendr_template(
-    "cran/configure.win",
-    save_as = "configure.win",
-    quiet = quiet,
-    overwrite = overwrite,
-    data = list(lib_name = lib_name)
-  )
-
   # use CRAN specific Makevars templates
   use_rextendr_template(
     "cran/Makevars",

--- a/R/use_extendr.R
+++ b/R/use_extendr.R
@@ -172,6 +172,43 @@ use_extendr <- function(path = ".",
     data = list(pkg_name = pkg_name)
   )
 
+  # create tools directory if it does not exist
+  if (!dir.exists("tools")) {
+    dir.create("tools")
+  }
+
+  # add msrv.R template
+  use_rextendr_template(
+    "cran/msrv.R",
+    save_as = file.path("tools", "msrv.R"),
+    quiet = quiet,
+    overwrite = overwrite
+  )
+
+  # add configure and configure.win templates
+  use_rextendr_template(
+    "cran/configure",
+    save_as = "configure",
+    quiet = quiet,
+    overwrite = overwrite,
+    data = list(lib_name = lib_name)
+  )
+
+  # configure needs to be made executable
+  # ignore for Windows
+  if (.Platform[["OS.type"]] == "unix") {
+    Sys.chmod("configure", "0755")
+  }
+
+  use_rextendr_template(
+    "cran/configure.win",
+    save_as = "configure.win",
+    quiet = quiet,
+    overwrite = overwrite,
+    data = list(lib_name = lib_name)
+  )
+
+
   if (!isTRUE(quiet)) {
     cli::cli_alert_success("Finished configuring {.pkg extendr} for package {.pkg {pkg_name}}.")
     cli::cli_ul(

--- a/inst/templates/Makevars
+++ b/inst/templates/Makevars
@@ -3,6 +3,9 @@ LIBDIR = $(TARGET_DIR)/release
 STATLIB = $(LIBDIR)/lib{{{lib_name}}}.a
 PKG_LIBS = -L$(LIBDIR) -l{{{lib_name}}}
 
+# Print linked static libraries at compile time
+export RUSTFLAGS=--print=native-static-libs
+
 all: C_clean
 
 $(SHLIB): $(STATLIB)

--- a/inst/templates/Makevars.win
+++ b/inst/templates/Makevars.win
@@ -5,6 +5,9 @@ LIBDIR = $(TARGET_DIR)/$(TARGET)/release
 STATLIB = $(LIBDIR)/lib{{{lib_name}}}.a
 PKG_LIBS = -L$(LIBDIR) -l{{{lib_name}}} -lws2_32 -ladvapi32 -luserenv -lbcrypt -lntdll
 
+# Print linked static libraries at compile time
+export RUSTFLAGS=--print=native-static-libs
+
 all: C_clean
 
 $(SHLIB): $(STATLIB)

--- a/inst/templates/cran/Makevars
+++ b/inst/templates/cran/Makevars
@@ -3,6 +3,9 @@ LIBDIR = $(TARGET_DIR)/release
 STATLIB = $(LIBDIR)/lib{{{lib_name}}}.a
 PKG_LIBS = -L$(LIBDIR) -l{{{lib_name}}}
 
+# Print linked static libraries at compile time
+export RUSTFLAGS=--print=native-static-libs
+
 all: C_clean
 
 $(SHLIB): $(STATLIB)

--- a/inst/templates/cran/Makevars.win
+++ b/inst/templates/cran/Makevars.win
@@ -5,6 +5,9 @@ LIBDIR = $(TARGET_DIR)/$(TARGET)/release
 STATLIB = $(LIBDIR)/lib{{{lib_name}}}.a
 PKG_LIBS = -L$(LIBDIR) -l{{{lib_name}}} -lws2_32 -ladvapi32 -luserenv -lbcrypt -lntdll
 
+# Print linked static libraries at compile time
+export RUSTFLAGS=--print=native-static-libs
+
 all: C_clean
 
 $(SHLIB): $(STATLIB)

--- a/tests/testthat/_snaps/use_cran_defaults.md
+++ b/tests/testthat/_snaps/use_cran_defaults.md
@@ -17,6 +17,9 @@
       v Writing 'src/rust/src/lib.rs'
       v Writing 'src/testpkg-win.def'
       v Writing 'R/extendr-wrappers.R'
+      v Writing 'tools/msrv.R'
+      v Writing 'configure'
+      v Writing 'configure.win'
       v Finished configuring extendr for package testpkg.
       * Please run `rextendr::document()` for changes to take effect.
 
@@ -25,9 +28,9 @@
     Code
       use_cran_defaults()
     Message
-      v Writing 'tools/msrv.R'
-      v Writing 'configure'
-      v Writing 'configure.win'
+      > File 'tools/msrv.R' already exists. Skip writing the file.
+      > File 'configure' already exists. Skip writing the file.
+      > File 'configure.win' already exists. Skip writing the file.
       > File 'src/Makevars' already exists. Skip writing the file.
       > File 'src/Makevars.win' already exists. Skip writing the file.
       v Adding "^src/rust/vendor$" to '.Rbuildignore'.

--- a/tests/testthat/_snaps/use_cran_defaults.md
+++ b/tests/testthat/_snaps/use_cran_defaults.md
@@ -12,7 +12,7 @@
       v Writing 'src/Makevars.win'
       v Writing 'src/Makevars.ucrt'
       v Writing 'src/.gitignore'
-      v Adding '^src/\\.cargo$' to '.Rbuildignore'
+      v Adding "^src/\\.cargo$" to '.Rbuildignore'.
       v Writing 'src/rust/Cargo.toml'
       v Writing 'src/rust/src/lib.rs'
       v Writing 'src/testpkg-win.def'
@@ -30,8 +30,8 @@
       v Writing 'configure.win'
       > File 'src/Makevars' already exists. Skip writing the file.
       > File 'src/Makevars.win' already exists. Skip writing the file.
-      v Adding '^src/rust/vendor$' to '.Rbuildignore'
-      v Adding 'src/rust/vendor' to '.gitignore'
+      v Adding "^src/rust/vendor$" to '.Rbuildignore'.
+      v Adding "src/rust/vendor" to '.gitignore'.
 
 ---
 

--- a/tests/testthat/_snaps/use_cran_defaults.md
+++ b/tests/testthat/_snaps/use_cran_defaults.md
@@ -28,9 +28,6 @@
     Code
       use_cran_defaults()
     Message
-      > File 'tools/msrv.R' already exists. Skip writing the file.
-      > File 'configure' already exists. Skip writing the file.
-      > File 'configure.win' already exists. Skip writing the file.
       > File 'src/Makevars' already exists. Skip writing the file.
       > File 'src/Makevars.win' already exists. Skip writing the file.
       v Adding "^src/rust/vendor$" to '.Rbuildignore'.

--- a/tests/testthat/_snaps/use_cran_defaults.md
+++ b/tests/testthat/_snaps/use_cran_defaults.md
@@ -12,7 +12,7 @@
       v Writing 'src/Makevars.win'
       v Writing 'src/Makevars.ucrt'
       v Writing 'src/.gitignore'
-      v Adding "^src/\\.cargo$" to '.Rbuildignore'.
+      v Adding '^src/\\.cargo$' to '.Rbuildignore'
       v Writing 'src/rust/Cargo.toml'
       v Writing 'src/rust/src/lib.rs'
       v Writing 'src/testpkg-win.def'
@@ -30,8 +30,8 @@
       v Writing 'configure.win'
       > File 'src/Makevars' already exists. Skip writing the file.
       > File 'src/Makevars.win' already exists. Skip writing the file.
-      v Adding "^src/rust/vendor$" to '.Rbuildignore'.
-      v Adding "src/rust/vendor" to '.gitignore'.
+      v Adding '^src/rust/vendor$' to '.Rbuildignore'
+      v Adding 'src/rust/vendor' to '.gitignore'
 
 ---
 
@@ -42,6 +42,9 @@
       LIBDIR = $(TARGET_DIR)/release
       STATLIB = $(LIBDIR)/libtestpkg.a
       PKG_LIBS = -L$(LIBDIR) -ltestpkg
+      
+      # Print linked static libraries at compile time
+      export RUSTFLAGS=--print=native-static-libs
       
       all: C_clean
       
@@ -80,6 +83,9 @@
       LIBDIR = $(TARGET_DIR)/$(TARGET)/release
       STATLIB = $(LIBDIR)/libtestpkg.a
       PKG_LIBS = -L$(LIBDIR) -ltestpkg -lws2_32 -ladvapi32 -luserenv -lbcrypt -lntdll
+      
+      # Print linked static libraries at compile time
+      export RUSTFLAGS=--print=native-static-libs
       
       all: C_clean
       

--- a/tests/testthat/_snaps/use_extendr.md
+++ b/tests/testthat/_snaps/use_extendr.md
@@ -17,6 +17,9 @@
       v Writing 'src/rust/src/lib.rs'
       v Writing 'src/testpkg-win.def'
       v Writing 'R/extendr-wrappers.R'
+      v Writing 'tools/msrv.R'
+      v Writing 'configure'
+      v Writing 'configure.win'
       v Finished configuring extendr for package testpkg.
       * Please run `rextendr::document()` for changes to take effect.
 
@@ -218,6 +221,9 @@
       > File 'src/rust/src/lib.rs' already exists. Skip writing the file.
       > File 'src/testpkg.wrap-win.def' already exists. Skip writing the file.
       > File 'R/extendr-wrappers.R' already exists. Skip writing the file.
+      > File 'tools/msrv.R' already exists. Skip writing the file.
+      > File 'configure' already exists. Skip writing the file.
+      > File 'configure.win' already exists. Skip writing the file.
       v Finished configuring extendr for package testpkg.wrap.
       * Please run `rextendr::document()` for changes to take effect.
 
@@ -235,6 +241,9 @@
       v Writing 'src/rust/src/lib.rs'
       v Writing 'src/testpkg-win.def'
       > File 'R/extendr-wrappers.R' already exists. Skip writing the file.
+      v Writing 'tools/msrv.R'
+      v Writing 'configure'
+      v Writing 'configure.win'
       v Finished configuring extendr for package testpkg.
       * Please run `rextendr::document()` for changes to take effect.
 

--- a/tests/testthat/_snaps/use_extendr.md
+++ b/tests/testthat/_snaps/use_extendr.md
@@ -12,7 +12,7 @@
       v Writing 'src/Makevars.win'
       v Writing 'src/Makevars.ucrt'
       v Writing 'src/.gitignore'
-      v Adding "^src/\\.cargo$" to '.Rbuildignore'.
+      v Adding '^src/\\.cargo$' to '.Rbuildignore'
       v Writing 'src/rust/Cargo.toml'
       v Writing 'src/rust/src/lib.rs'
       v Writing 'src/testpkg-win.def'
@@ -47,6 +47,9 @@
       LIBDIR = $(TARGET_DIR)/release
       STATLIB = $(LIBDIR)/libtestpkg.a
       PKG_LIBS = -L$(LIBDIR) -ltestpkg
+      
+      # Print linked static libraries at compile time
+      export RUSTFLAGS=--print=native-static-libs
       
       all: C_clean
       
@@ -85,6 +88,9 @@
       LIBDIR = $(TARGET_DIR)/$(TARGET)/release
       STATLIB = $(LIBDIR)/libtestpkg.a
       PKG_LIBS = -L$(LIBDIR) -ltestpkg -lws2_32 -ladvapi32 -luserenv -lbcrypt -lntdll
+      
+      # Print linked static libraries at compile time
+      export RUSTFLAGS=--print=native-static-libs
       
       all: C_clean
       
@@ -259,6 +265,9 @@
       LIBDIR = $(TARGET_DIR)/release
       STATLIB = $(LIBDIR)/libbar.a
       PKG_LIBS = -L$(LIBDIR) -lbar
+      
+      # Print linked static libraries at compile time
+      export RUSTFLAGS=--print=native-static-libs
       
       all: C_clean
       

--- a/tests/testthat/_snaps/use_extendr.md
+++ b/tests/testthat/_snaps/use_extendr.md
@@ -12,7 +12,7 @@
       v Writing 'src/Makevars.win'
       v Writing 'src/Makevars.ucrt'
       v Writing 'src/.gitignore'
-      v Adding '^src/\\.cargo$' to '.Rbuildignore'
+      v Adding "^src/\\.cargo$" to '.Rbuildignore'.
       v Writing 'src/rust/Cargo.toml'
       v Writing 'src/rust/src/lib.rs'
       v Writing 'src/testpkg-win.def'


### PR DESCRIPTION
Per suggestion of Yutanni, we should add `--print=native-static-libs` which gives us insight into which linker flags need to be visible when building our crate.

If a user encounters an error building, they can check the output.

