### PR TITLE
Fix anonymous function usage

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -49,7 +49,7 @@ cargo_command_available <- function(args = "--help") {
 try_exec_cmd <- function(cmd, args = character()) {
   result <- tryCatch(
     processx::run(cmd, args, error_on_status = FALSE),
-    error = \(...) list(status = -1)
+    error = function(...) list(status = -1)
   )
   if (result[["status"]] != 0) {
     NA_character_


### PR DESCRIPTION
- Fixes #395
- Makes `{rextendr}` R >= 4.0 complaint