### PR TITLE
internal utilities to find rust crate and cargo manifest

### DIFF
--- a/R/find_extendr.R
+++ b/R/find_extendr.R
@@ -44,6 +44,8 @@ find_extendr_crate <- function(
 #' @examples
 #' \dontrun{
 #' find_extendr_manifest()
+#' @keywords internal
+#' @noRd
 #' }
 find_extendr_manifest <- function(
     path = ".",

--- a/R/find_extendr.R
+++ b/R/find_extendr.R
@@ -9,6 +9,8 @@
 #' @examples
 #' \dontrun{
 #' find_extendr_crate()
+#' @keywords internal
+#' @noRd
 #' }
 find_extendr_crate <- function(
     path = ".",

--- a/R/find_extendr.R
+++ b/R/find_extendr.R
@@ -1,0 +1,65 @@
+#' Get path to Rust crate in R package directory
+#'
+#' @param path character scalar, the R package directory
+#' @param error_call call scalar, from rlang docs: "the defused call with which
+#' the function running in the frame was invoked"
+#'
+#' @return character scalar, path to Rust crate
+#'
+#' @examples
+#' \dontrun{
+#' find_extendr_crate()
+#' }
+find_extendr_crate <- function(
+    path = ".",
+    error_call = rlang::caller_call()) {
+  check_character(path, call = error_call, class = "rextendr_error")
+
+  rust_folder <- rprojroot::find_package_root_file(
+    "src", "rust",
+    path = path
+  )
+
+  if (!dir.exists(rust_folder)) {
+    cli::cli_abort(
+      "Could not find Rust crate at {.path rust_folder}.",
+      call = error_call,
+      class = "rextendr_error"
+    )
+  }
+
+  rust_folder
+}
+
+#' Get path to Cargo manifest in R package directory
+#'
+#' @param path character scalar, the R package directory
+#' @param error_call call scalar, from rlang docs: "the defused call with which
+#' the function running in the frame was invoked"
+#'
+#' @return character scalar, path to Cargo manifest
+#'
+#' @examples
+#' \dontrun{
+#' find_extendr_manifest()
+#' }
+find_extendr_manifest <- function(
+    path = ".",
+    error_call = rlang::caller_call()) {
+  check_character(path, call = error_call, class = "rextendr_error")
+
+  manifest_path <- rprojroot::find_package_root_file(
+    "src", "rust", "Cargo.toml",
+    path = path
+  )
+
+  if (!file.exists(manifest_path)) {
+    cli::cli_abort(
+      "Could not find Cargo manifest at {.path manifest_path}.",
+      call = error_call,
+      class = "rextendr_error"
+    )
+  }
+
+  manifest_path
+}

--- a/tests/testthat/test-find_extendr.R
+++ b/tests/testthat/test-find_extendr.R
@@ -1,0 +1,33 @@
+test_that("find_extendr_crate() returns path to Rust crate", {
+  skip_if_not_installed("usethis")
+
+  path <- local_package("testpkg")
+
+  # capture setup messages
+  withr::local_options(usethis.quiet = FALSE)
+
+  expect_error(find_extendr_crate(), class = "rextendr_error")
+
+  use_extendr(path, quiet = TRUE)
+
+  rust_folder <- find_extendr_crate()
+
+  expect_true(dir.exists(rust_folder))
+})
+
+test_that("find_extendr_manifest() returns path to Cargo manifest", {
+  skip_if_not_installed("usethis")
+
+  path <- local_package("testpkg")
+
+  # capture setup messages
+  withr::local_options(usethis.quiet = FALSE)
+
+  expect_error(find_extendr_manifest(), class = "rextendr_error")
+
+  use_extendr(path, quiet = TRUE)
+
+  manifest_path <- find_extendr_manifest()
+
+  expect_true(file.exists(manifest_path))
+})


### PR DESCRIPTION
This PR adds internal utility functions that find R package root, build path from there to crate directory or Cargo.toml, and check that directory or file exists. Both return paths. These can be used to consolidate code and provide stronger checks. 

Note: this is to simplify efforts to refactor functions to execute Cargo subcommands using `processx::run()` in PR https://github.com/extendr/rextendr/pull/397.