### PR TITLE
chore: increase code coverage

### DIFF
--- a/R/cran-compliance.R
+++ b/R/cran-compliance.R
@@ -25,12 +25,12 @@ vendor_pkgs <- function(path = ".", quiet = FALSE, overwrite = NULL) {
   local_quiet_cli(quiet)
 
   # get path to rust folder
-  src_dir <- rprojroot::find_package_root_file(path, "src/rust")
+  src_dir <- rprojroot::find_package_root_file("src", "rust", path = path)
 
   # if `src/rust` does not exist error
   if (!dir.exists(src_dir)) {
     cli::cli_abort(
-      c("{.path src/rust} cannot be found", "i" = "Did you run {.fn use_extendr}?"),
+      "{.path src/rust} cannot be found. Did you run {.fn use_extendr}?",
       class = "rextendr_error"
     )
   }

--- a/R/use_msrv.R
+++ b/R/use_msrv.R
@@ -52,14 +52,16 @@ use_msrv <- function(version, path = ".", overwrite = FALSE) {
     )
   })
 
-  desc_path <- rprojroot::find_package_root_file("DESCRIPTION", path = path)
-
-  if (!file.exists(desc_path)) {
-    cli::cli_abort(
-      "{.arg path} ({.path {path}}) does not contain a DESCRIPTION",
-      class = "rextendr_error"
-    )
-  }
+  desc_path <- rlang::try_fetch(
+    rprojroot::find_package_root_file("DESCRIPTION", path = path),
+    error = function(cnd) {
+      cli::cli_abort(
+        "{.arg path} ({.path {path}}) does not contain a DESCRIPTION",
+        class = "rextendr_error",
+        call = rlang::env_parent()
+      )
+    }
+  )
 
   cur <- paste("Cargo (Rust's package manager), rustc", paste(">=", version))
 

--- a/tests/testthat/test-cran-compliance.R
+++ b/tests/testthat/test-cran-compliance.R
@@ -2,6 +2,8 @@ test_that("vendor_pkgs() vendors dependencies", {
   skip_if_not_installed("usethis")
 
   path <- local_package("testpkg")
+
+  expect_error(vendor_pkgs(path))
   # capture setup messages
   withr::local_options(usethis.quiet = FALSE)
   use_extendr(path, quiet = TRUE)

--- a/tests/testthat/test-rstudio-template.R
+++ b/tests/testthat/test-rstudio-template.R
@@ -1,0 +1,25 @@
+test_that("RStudio template generation is correct", {
+  pkg_name <- "extendrtest"
+  tmp <- file.path(tempdir(), pkg_name)
+
+  pkg <- create_extendr_package(
+    tmp,
+    roxygen = TRUE,
+    check_name = FALSE,
+    crate_name = pkg_name,
+    lib_name = pkg_name,
+    edition = "2021"
+  )
+
+  expected_files <- c(
+    "configure", "configure.win", "DESCRIPTION",
+    "extendrtest.Rproj", "NAMESPACE", "R/extendr-wrappers.R",
+    "src/entrypoint.c", "src/extendrtest-win.def",
+    "src/Makevars.in", "src/Makevars.ucrt", "src/Makevars.win.in",
+    "src/rust/Cargo.toml", "src/rust/src/lib.rs", "tools/msrv.R"
+  )
+
+  for (file in expected_files) {
+    expect_true(file.exists(file.path(tmp, file)))
+  }
+})

--- a/tests/testthat/test-use_msrv.R
+++ b/tests/testthat/test-use_msrv.R
@@ -7,12 +7,22 @@ test_that("use_msrv() modifies the MSRV in the DESCRIPTION", {
   withr::local_options(usethis.quiet = FALSE)
 
   use_extendr(path, quiet = TRUE)
-  use_msrv("1.70", path)
+  expect_no_error(use_msrv("1.70", path))
 
   d <- desc::desc("DESCRIPTION")
 
   expect_identical(
     "Cargo (Rust's package manager), rustc >= 1.70",
     d$get_field("SystemRequirements")
+  )
+
+  expect_error(use_msrv("adksfghu", path))
+
+  expect_error(use_msrv("1.70", path = "../doesntexist"))
+
+  # when overwrite is FALSE and SystemRequirements is already set
+  expect_message(
+    use_msrv("1.65", overwrite = FALSE),
+    "The SystemRequirements field in the "
   )
 })


### PR DESCRIPTION
This PR seeks to improve the overall code coverage of {rextendr} without using snapshot tests. 

This will hopefully help us identify any regressions in the future. 