### PR TITLE
Propagate the error causing `rextendr::document()` to fail

### DIFF
--- a/R/register_extendr.R
+++ b/R/register_extendr.R
@@ -100,7 +100,10 @@ register_extendr <- function(path = ".", quiet = FALSE, force = FALSE, compile =
     ),
     error = function(e) {
       cli::cli_abort(
-        c("Failed to generate wrapper functions.", x = e[["message"]]),
+        c("Failed to generate wrapper functions.",
+x = e[["message"]],
+          y = e[["parent"]][["message"]]
+),
         class = "rextendr_error"
       )
     }
@@ -118,7 +121,7 @@ register_extendr <- function(path = ".", quiet = FALSE, force = FALSE, compile =
 #' @param package_name The name of the package.
 #' @param outfile Determines where to write wrapper code.
 #' @param path Path from which package root is looked up. Used for message formatting.
-#' @param use_symbols Logical, indicating wether to add additonal symbol information to
+#' @param use_symbols Logical, indicating wether to add additional symbol information to
 #' the generated wrappers. Default (`FALSE`) is used when making wrappers for the package,
 #' while `TRUE` is used to make wrappers for dynamically generated libraries using
 #' [`rust_source`], [`rust_function`], etc.

--- a/R/register_extendr.R
+++ b/R/register_extendr.R
@@ -101,9 +101,9 @@ register_extendr <- function(path = ".", quiet = FALSE, force = FALSE, compile =
     error = function(e) {
       cli::cli_abort(
         c("Failed to generate wrapper functions.",
-x = e[["message"]],
+          x = e[["message"]],
           y = e[["parent"]][["message"]]
-),
+        ),
         class = "rextendr_error"
       )
     }


### PR DESCRIPTION
This has been a nuisance for many, many years now already.

Invoking `rextendr::document()` invokes `{callr}`'s `r` function, which spawns a separate R process, meant to load the wrapper-generating functions that are part of the rust-powered r-package, and write that to disk. Unfortunately, if there are any errors attributed with this call, then we do not see the error. The error could be missing libraries in `Makevars` (there are related issues), or anything similar, then you don't get the error message.

With this slight change, the error message is propagated.

## Example

Current behaviour:

```r
Error in `value[[3L]]()`:
! Failed to generate wrapper functions.
✖ in callr subprocess.
Backtrace:
    ▆
 1. └─rextendr::document()
 2.   └─rextendr::register_extendr(path = pkg, quiet = quiet)
 3.     └─base::tryCatch(...)
 4.       └─base (local) tryCatchList(expr, classes, parentenv, handlers)
 5.         └─base (local) tryCatchOne(expr, names, parentenv, handlers[[1L]])
 6.           └─value[[3L]](cond)
 7.             └─cli::cli_abort(...)
 8.               └─rlang::abort(...)
 ```
New behaviour:
```r
Error in `value[[3L]]()`:
! Failed to generate wrapper functions.
✖ in callr subprocess.
"wrap2__make_extendrtests_wrappers" not available for .Call() for package "extendrtests"
```

And yes I was refactoring the way wrapper-generating works in `extendr-macros`+`extendr-api`.
