### PR TITLE
Add `url` field in `pkgdown` config

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,3 +1,4 @@
+url: https://extendr.github.io/rextendr/
 template:
   bootstrap: 5
 development:


### PR DESCRIPTION
Currently, being on `https://extendr.github.io/rextendr/`, searching "source" (for example) and clicking on the first result in "Reference" gives a 404. This is because the URL is `https://extendr.github.io/reference/make_module_macro.html?q=source` (missing `rextendr` at the beginning).

I think using the `url` field should fix that.