### PR TITLE
fix: Remove unnecessary makevars.ucrt

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -4,3 +4,6 @@ linters: linters_with_defaults(
     commented_code_linter = NULL
     )
 encoding: "UTF-8"
+exclusions: list(
+      "R/import-standalone-obj-type.R"
+    )

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # rextendr (development version)
 
+* Removes `Makevars.ucrt` as R versions < 4.1 are not supported by extendr <https://github.com/extendr/rextendr/pull/414> 
 * `purrr` has been replaced with [`R/standalone-purrr.R`](https://github.com/r-lib/rlang/blob/main/R/standalone-purrr.R) removing `purrr` from `Imports` <https://github.com/extendr/rextendr/pull/408>
 * `document()` will no longer try to save all open files using rstudioapi <https://github.com/extendr/rextendr/issues/404> <https://github.com/extendr/rextendr/issues/407>
 * `use_cran_default()` has been removed as the default package template is CRAN compatible <https://github.com/extendr/rextendr/pull/394>

--- a/R/source.R
+++ b/R/source.R
@@ -503,7 +503,7 @@ get_specific_target_name <- function() {
     )
   }
 
-  return(NULL)
+  NULL
 }
 
 the <- new.env(parent = emptyenv())

--- a/R/use_extendr.R
+++ b/R/use_extendr.R
@@ -117,14 +117,6 @@ use_extendr <- function(path = ".",
   )
 
   use_rextendr_template(
-    "Makevars.ucrt",
-    save_as = file.path("src", "Makevars.ucrt"),
-    quiet = quiet,
-    overwrite = overwrite,
-    data = list(lib_name = lib_name)
-  )
-
-  use_rextendr_template(
     "_gitignore",
     save_as = file.path("src", ".gitignore"),
     quiet = quiet,

--- a/inst/templates/Makevars.win.in
+++ b/inst/templates/Makevars.win.in
@@ -31,7 +31,6 @@ $(STATLIB):
 		fi; \
 	fi
 
-	# CARGO_LINKER is provided in Makevars.ucrt for R >= 4.2
 	# Build the project using Cargo with additional flags
 	export CARGO_HOME=$(CARGOTMP) && \
 	export CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER="$(CARGO_LINKER)" && \

--- a/tests/testthat/_snaps/use_extendr.md
+++ b/tests/testthat/_snaps/use_extendr.md
@@ -313,7 +313,6 @@
       		fi; \
       	fi
       
-      	# CARGO_LINKER is provided in Makevars.ucrt for R >= 4.2
       	# Build the project using Cargo with additional flags
       	export CARGO_HOME=$(CARGOTMP) && \
       	export CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER="$(CARGO_LINKER)" && \
@@ -328,17 +327,6 @@
       
       clean:
       	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS) $(TARGET_DIR)
-
----
-
-    Code
-      cat_file("src", "Makevars.ucrt")
-    Output
-      # Rtools42 doesn't have the linker in the location that cargo expects, so we
-      # need to overwrite it via configuration.
-      CARGO_LINKER = x86_64-w64-mingw32.static.posix-gcc.exe
-      
-      include Makevars.win
 
 ---
 
@@ -401,7 +389,6 @@
       > File 'src/entrypoint.c' already exists. Skip writing the file.
       > File 'src/Makevars.in' already exists. Skip writing the file.
       > File 'src/Makevars.win.in' already exists. Skip writing the file.
-      > File 'src/Makevars.ucrt' already exists. Skip writing the file.
       > File 'src/.gitignore' already exists. Skip writing the file.
       > File 'src/rust/Cargo.toml' already exists. Skip writing the file.
       > File 'src/rust/src/lib.rs' already exists. Skip writing the file.
@@ -421,7 +408,6 @@
       v Writing 'src/entrypoint.c'
       v Writing 'src/Makevars.in'
       v Writing 'src/Makevars.win.in'
-      v Writing 'src/Makevars.ucrt'
       v Writing 'src/.gitignore'
       v Writing 'src/rust/Cargo.toml'
       v Writing 'src/rust/src/lib.rs'

--- a/tests/testthat/test-rstudio-template.R
+++ b/tests/testthat/test-rstudio-template.R
@@ -15,7 +15,7 @@ test_that("RStudio template generation is correct", {
     "configure", "configure.win", "DESCRIPTION",
     "extendrtest.Rproj", "NAMESPACE", "R/extendr-wrappers.R",
     "src/entrypoint.c", "src/extendrtest-win.def",
-    "src/Makevars.in", "src/Makevars.ucrt", "src/Makevars.win.in",
+    "src/Makevars.in", "src/Makevars.win.in",
     "src/rust/Cargo.toml", "src/rust/src/lib.rs", "tools/msrv.R"
   )
 

--- a/tests/testthat/test-use_extendr.R
+++ b/tests/testthat/test-use_extendr.R
@@ -29,7 +29,6 @@ test_that("use_extendr() sets up extendr files correctly", {
   expect_snapshot(cat_file("src", "Makevars.in"))
   expect_snapshot(cat_file("src", "entrypoint.c"))
   expect_snapshot(cat_file("src", "Makevars.win.in"))
-  expect_snapshot(cat_file("src", "Makevars.ucrt"))
   expect_snapshot(cat_file("src", "testpkg-win.def"))
   expect_snapshot(cat_file("src", "rust", "Cargo.toml"))
   expect_snapshot(cat_file("src", "rust", "src", "lib.rs"))


### PR DESCRIPTION
Removes `makevars.ucrt` templates and updates tests and snaps. Closes #332 .