### PR TITLE
Address R CMD check `_abort` WARNING

### DIFF
--- a/.github/workflows/test_pkg_gen.yaml
+++ b/.github/workflows/test_pkg_gen.yaml
@@ -120,6 +120,6 @@ jobs:
 
           # check if compile = TRUE forces compile, and accordingly the wrapper generation
           rextendr::register_extendr(compile = TRUE)
-          stopifnot(library_mtime_before <= file.info(library_path)$mtime)
-          stopifnot(wrappers_mtime_before <= file.info(wrappers_path)$mtime)
+          stopifnot(library_mtime_before < file.info(library_path)$mtime)
+          stopifnot(wrappers_mtime_before < file.info(wrappers_path)$mtime)
         shell: Rscript {0}

--- a/.github/workflows/test_pkg_gen.yaml
+++ b/.github/workflows/test_pkg_gen.yaml
@@ -120,6 +120,7 @@ jobs:
 
           # check if compile = TRUE forces compile, and accordingly the wrapper generation
           rextendr::register_extendr(compile = TRUE)
+          devtools::load_all()
           stopifnot(library_mtime_before < file.info(library_path)$mtime)
           stopifnot(wrappers_mtime_before < file.info(wrappers_path)$mtime)
         shell: Rscript {0}

--- a/.github/workflows/test_pkg_gen.yaml
+++ b/.github/workflows/test_pkg_gen.yaml
@@ -120,6 +120,6 @@ jobs:
 
           # check if compile = TRUE forces compile, and accordingly the wrapper generation
           rextendr::register_extendr(compile = TRUE)
-          stopifnot(library_mtime_before < file.info(library_path)$mtime)
-          stopifnot(wrappers_mtime_before < file.info(wrappers_path)$mtime)
+          stopifnot(library_mtime_before <= file.info(library_path)$mtime)
+          stopifnot(wrappers_mtime_before <= file.info(wrappers_path)$mtime)
         shell: Rscript {0}

--- a/.github/workflows/test_pkg_gen.yaml
+++ b/.github/workflows/test_pkg_gen.yaml
@@ -120,7 +120,7 @@ jobs:
 
           # check if compile = TRUE forces compile, and accordingly the wrapper generation
           rextendr::register_extendr(compile = TRUE)
-          devtools::load_all()
+
           stopifnot(library_mtime_before < file.info(library_path)$mtime)
           stopifnot(wrappers_mtime_before < file.info(wrappers_path)$mtime)
         shell: Rscript {0}

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # rextendr (development version)
 
+* Addresses new CRAN check in R 4.5+ adding warning for `_abort` usage
 * Removes `Makevars.ucrt` as R versions < 4.1 are not supported by extendr <https://github.com/extendr/rextendr/pull/414> 
 * `purrr` has been replaced with [`R/standalone-purrr.R`](https://github.com/r-lib/rlang/blob/main/R/standalone-purrr.R) removing `purrr` from `Imports` <https://github.com/extendr/rextendr/pull/408>
 * `document()` will no longer try to save all open files using rstudioapi <https://github.com/extendr/rextendr/issues/404> <https://github.com/extendr/rextendr/issues/407>

--- a/R/use_extendr.R
+++ b/R/use_extendr.R
@@ -21,12 +21,14 @@
 #' @return A logical value (invisible) indicating whether any package files were
 #' generated or not.
 #' @export
-use_extendr <- function(path = ".",
-                        crate_name = NULL,
-                        lib_name = NULL,
-                        quiet = FALSE,
-                        overwrite = NULL,
-                        edition = c("2021", "2018")) {
+use_extendr <- function(
+  path = ".",
+  crate_name = NULL,
+  lib_name = NULL,
+  quiet = FALSE,
+  overwrite = NULL,
+  edition = c("2021", "2018")
+) {
   # https://github.com/r-lib/cli/issues/434
 
   local_quiet_cli(quiet)
@@ -80,7 +82,6 @@ use_extendr <- function(path = ".",
   src_dir <- rprojroot::find_package_root_file("src")
   r_dir <- rprojroot::find_package_root_file("R")
 
-
   if (!dir.exists(r_dir)) {
     dir.create(r_dir)
     cli::cli_alert_success("Creating {.file {pretty_rel_path(r_dir, path)}}.")
@@ -89,7 +90,9 @@ use_extendr <- function(path = ".",
   rust_src_dir <- file.path(src_dir, "rust", "src")
   if (!dir.exists(rust_src_dir)) {
     dir.create(rust_src_dir, recursive = TRUE)
-    cli::cli_alert_success("Creating {.file {pretty_rel_path(rust_src_dir, path)}}.")
+    cli::cli_alert_success(
+      "Creating {.file {pretty_rel_path(rust_src_dir, path)}}."
+    )
   }
 
   use_rextendr_template(
@@ -125,7 +128,12 @@ use_extendr <- function(path = ".",
 
   edition <- match.arg(edition, several.ok = FALSE)
   cargo_toml_content <- to_toml(
-    package = list(name = crate_name, publish = FALSE, version = "0.1.0", edition = edition),
+    package = list(
+      name = crate_name,
+      publish = FALSE,
+      version = "0.1.0",
+      edition = edition
+    ),
     lib = list(`crate-type` = array("staticlib", 1), name = lib_name),
     dependencies = list(`extendr-api` = "*")
   )
@@ -210,6 +218,11 @@ use_extendr <- function(path = ".",
     file.path("src", "rust", "vendor")
   )
 
+  # ensure that the target directory is ignored
+  usethis::use_build_ignore(
+    file.path("src", "rust", "target")
+  )
+
   # the src/Makevars should be created each time the package
   # is built. This is handled via the configure file
   usethis::use_build_ignore("src/Makevars")
@@ -218,7 +231,9 @@ use_extendr <- function(path = ".",
   usethis::use_git_ignore("src/Makevars.win")
 
   if (!isTRUE(quiet)) {
-    cli::cli_alert_success("Finished configuring {.pkg extendr} for package {.pkg {pkg_name}}.")
+    cli::cli_alert_success(
+      "Finished configuring {.pkg extendr} for package {.pkg {pkg_name}}."
+    )
     cli::cli_ul(
       c(
         "Please run {.fun rextendr::document} for changes to take effect."
@@ -230,7 +245,10 @@ use_extendr <- function(path = ".",
 }
 
 try_get_normalized_path <- function(path_fn) {
-  tryCatch(normalizePath(path_fn(), winslash = "/", mustWork = FALSE), error = function(e) NA)
+  tryCatch(
+    normalizePath(path_fn(), winslash = "/", mustWork = FALSE),
+    error = function(e) NA
+  )
 }
 
 try_get_proj_path <- function() {
@@ -238,7 +256,9 @@ try_get_proj_path <- function() {
 }
 
 try_get_root_path <- function(path) {
-  try_get_normalized_path(function() rprojroot::find_package_root_file(path = path))
+  try_get_normalized_path(
+    function() rprojroot::find_package_root_file(path = path)
+  )
 }
 
 #' Checks if provided name is a valid Rust name (identifier)
@@ -298,15 +318,19 @@ throw_if_invalid_rust_name <- function(name, call = caller_env()) {
 #' be overwritten in an interactive session or do nothing in a non-interactive session.
 #' Otherwise, the file will be overwritten.
 #' @noRd
-use_rextendr_template <- function(template,
-                                  save_as = template,
-                                  data = list(),
-                                  quiet = FALSE,
-                                  overwrite = NULL) {
+use_rextendr_template <- function(
+  template,
+  save_as = template,
+  data = list(),
+  quiet = FALSE,
+  overwrite = NULL
+) {
   local_quiet_cli(quiet)
 
   if (isFALSE(overwrite) && file.exists(save_as)) {
-    cli::cli_alert("File {.path {save_as}} already exists. Skip writing the file.")
+    cli::cli_alert(
+      "File {.path {save_as}} already exists. Skip writing the file."
+    )
     return(invisible(NULL))
   }
 
@@ -334,7 +358,8 @@ use_rextendr_template <- function(template,
   template_content <- glue::glue_data(
     template_content,
     .x = data,
-    .open = "{{{", .close = "}}}",
+    .open = "{{{",
+    .close = "}}}",
     .trim = FALSE
   )
 

--- a/R/use_extendr.R
+++ b/R/use_extendr.R
@@ -132,7 +132,8 @@ use_extendr <- function(
       name = crate_name,
       publish = FALSE,
       version = "0.1.0",
-      edition = edition
+      edition = edition,
+      `rust-version` = "1.68.0"
     ),
     lib = list(`crate-type` = array("staticlib", 1), name = lib_name),
     dependencies = list(`extendr-api` = "*")
@@ -183,6 +184,14 @@ use_extendr <- function(
     overwrite = overwrite
   )
 
+  # add config.R template
+  use_rextendr_template(
+    "config.R",
+    save_as = file.path("tools", "config.R"),
+    quiet = quiet,
+    overwrite = overwrite
+  )
+
   # add configure and configure.win templates
   use_rextendr_template(
     "configure",
@@ -205,6 +214,9 @@ use_extendr <- function(
   if (.Platform[["OS.type"]] == "unix") {
     Sys.chmod("configure", "0755")
   }
+
+  # Set the minimum version of R to 4.2 which is 64 bit
+  usethis::use_package("R", "Depends", "4.2")
 
   # the temporary cargo directory must be ignored
   usethis::use_build_ignore("src/.cargo")

--- a/R/use_extendr.R
+++ b/R/use_extendr.R
@@ -133,7 +133,7 @@ use_extendr <- function(
       publish = FALSE,
       version = "0.1.0",
       edition = edition,
-      `rust-version` = "1.68.0"
+      `rust-version` = "1.65"
     ),
     lib = list(`crate-type` = array("staticlib", 1), name = lib_name),
     dependencies = list(`extendr-api` = "*")

--- a/inst/templates/Makevars.in
+++ b/inst/templates/Makevars.in
@@ -3,7 +3,7 @@ LIBDIR = $(TARGET_DIR)/release
 STATLIB = $(LIBDIR)/lib{{{lib_name}}}.a
 PKG_LIBS = -L$(LIBDIR) -l{{{lib_name}}}
 
-all: $(SHLIB) C_clean
+all: $(SHLIB) rust_clean
 
 $(SHLIB): $(STATLIB)
 
@@ -37,8 +37,8 @@ $(STATLIB):
 	# Always clean up CARGOTMP
 	rm -Rf $(CARGOTMP);
 
-C_clean:
-	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS)
+rust_clean:
+	rm -Rf $(CARGOTMP) $(VENDOR_DIR) $(TARGET_DIR)
 
 clean:
-	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS) $(TARGET_DIR) $(VENDOR_DIR)
+	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS) $(TARGET_DIR)

--- a/inst/templates/Makevars.in
+++ b/inst/templates/Makevars.in
@@ -3,7 +3,7 @@ LIBDIR = $(TARGET_DIR)/release
 STATLIB = $(LIBDIR)/lib{{{lib_name}}}.a
 PKG_LIBS = -L$(LIBDIR) -l{{{lib_name}}}
 
-all: C_clean
+all: $(SHLIB) C_clean
 
 $(SHLIB): $(STATLIB)
 

--- a/inst/templates/Makevars.in
+++ b/inst/templates/Makevars.in
@@ -5,6 +5,8 @@ PKG_LIBS = -L$(LIBDIR) -l{{{lib_name}}}
 
 all: $(SHLIB) rust_clean
 
+.PHONY: $(STATLIB)
+
 $(SHLIB): $(STATLIB)
 
 CARGOTMP = $(CURDIR)/.cargo

--- a/inst/templates/Makevars.in
+++ b/inst/templates/Makevars.in
@@ -1,5 +1,5 @@
 TARGET_DIR = ./rust/target
-LIBDIR = $(TARGET_DIR)/release
+LIBDIR = $(TARGET_DIR)/@LIBDIR@
 STATLIB = $(LIBDIR)/lib{{{lib_name}}}.a
 PKG_LIBS = -L$(LIBDIR) -l{{{lib_name}}}
 
@@ -32,13 +32,13 @@ $(STATLIB):
 
 	export CARGO_HOME=$(CARGOTMP) && \
 	export PATH="$(PATH):$(HOME)/.cargo/bin" && \
-	RUSTFLAGS="$(RUSTFLAGS) --print=native-static-libs" cargo build @CRAN_FLAGS@ --lib --release --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
+	RUSTFLAGS="$(RUSTFLAGS) --print=native-static-libs" cargo build @CRAN_FLAGS@ --lib @PROFILE@ --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
 
 	# Always clean up CARGOTMP
 	rm -Rf $(CARGOTMP);
 
 rust_clean:
-	rm -Rf $(CARGOTMP) $(VENDOR_DIR) $(TARGET_DIR)
+	rm -Rf $(CARGOTMP) $(VENDOR_DIR) @CLEAN_TARGET@
 
 clean:
 	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS) $(TARGET_DIR)

--- a/inst/templates/Makevars.win.in
+++ b/inst/templates/Makevars.win.in
@@ -5,7 +5,7 @@ LIBDIR = $(TARGET_DIR)/$(TARGET)/release
 STATLIB = $(LIBDIR)/lib{{{lib_name}}}.a
 PKG_LIBS = -L$(LIBDIR) -l{{{lib_name}}} -lws2_32 -ladvapi32 -luserenv -lbcrypt -lntdll
 
-all: $(SHLIB) C_clean
+all: $(SHLIB) rust_clean
 
 $(SHLIB): $(STATLIB)
 
@@ -40,8 +40,8 @@ $(STATLIB):
 	# Always clean up CARGOTMP
 	rm -Rf $(CARGOTMP);
 
-C_clean:
-	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS)
+rust_clean:
+	rm -Rf $(CARGOTMP) $(VENDOR_DIR) $(TARGET_DIR)
 
 clean:
 	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS) $(TARGET_DIR)

--- a/inst/templates/Makevars.win.in
+++ b/inst/templates/Makevars.win.in
@@ -28,13 +28,13 @@ $(STATLIB):
 	export CARGO_HOME=$(CURDIR)/$(CARGOTMP) && \
 	export CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER="$(CARGO_LINKER)" && \
 	export LIBRARY_PATH="$(LIBRARY_PATH);$(CURDIR)/$(TARGET_DIR)/libgcc_mock" && \
-	RUSTFLAGS="$(RUSTFLAGS) --print=native-static-libs" cargo build --jobs 2 --offline --target=$(TARGET) --lib --release --manifest-path=rust/Cargo.toml --target-dir=$(TARGET_DIR)
+	RUSTFLAGS="$(RUSTFLAGS) --print=native-static-libs" cargo build @CRAN_FLAGS@ --target=$(TARGET) --lib @PROFILE@ --manifest-path=rust/Cargo.toml --target-dir=$(TARGET_DIR)
 
 	# Always clean up CARGOTMP
 	rm -Rf $(CARGOTMP);
 
 rust_clean:
-	rm -Rf $(CARGOTMP) $(VENDOR_DIR) $(TARGET_DIR)
+	rm -Rf $(CARGOTMP) $(VENDOR_DIR) @CLEAN_TARGET@
 
 clean:
 	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS) $(TARGET_DIR)

--- a/inst/templates/Makevars.win.in
+++ b/inst/templates/Makevars.win.in
@@ -1,7 +1,7 @@
 TARGET = $(subst 64,x86_64,$(subst 32,i686,$(WIN)))-pc-windows-gnu
 
 TARGET_DIR = ./rust/target
-LIBDIR = $(TARGET_DIR)/$(TARGET)/release
+LIBDIR = $(TARGET_DIR)/$(TARGET)/@LIBDIR@
 STATLIB = $(LIBDIR)/lib{{{lib_name}}}.a
 PKG_LIBS = -L$(LIBDIR) -l{{{lib_name}}} -lws2_32 -ladvapi32 -luserenv -lbcrypt -lntdll
 
@@ -10,19 +10,12 @@ all: $(SHLIB) rust_clean
 $(SHLIB): $(STATLIB)
 
 CARGOTMP = $(CURDIR)/.cargo
+VENDOR_DIR = vendor
 
 $(STATLIB):
 	mkdir -p $(TARGET_DIR)/libgcc_mock
-	# `rustc` adds `-lgcc_eh` flags to the compiler, but Rtools' GCC doesn't have
-	# `libgcc_eh` due to the compilation settings. So, in order to please the
-	# compiler, we need to add empty `libgcc_eh` to the library search paths.
-	#
-	# For more details, please refer to
-	# https://github.com/r-windows/rtools-packages/blob/2407b23f1e0925bbb20a4162c963600105236318/mingw-w64-gcc/PKGBUILD#L313-L316
 	touch $(TARGET_DIR)/libgcc_mock/libgcc_eh.a
 
-	# When the NOT_CRAN flag is *not* set, the vendor.tar.xz, if present,
-	# is unzipped and used for offline compilation.
 	if [ "$(NOT_CRAN)" != "true" ]; then \
 		if [ -f ./rust/vendor.tar.xz ]; then \
 			tar xf rust/vendor.tar.xz && \
@@ -32,10 +25,10 @@ $(STATLIB):
 	fi
 
 	# Build the project using Cargo with additional flags
-	export CARGO_HOME=$(CARGOTMP) && \
+	export CARGO_HOME=$(CURDIR)/$(CARGOTMP) && \
 	export CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER="$(CARGO_LINKER)" && \
-	export LIBRARY_PATH="$${LIBRARY_PATH};$(CURDIR)/$(TARGET_DIR)/libgcc_mock" && \
-	RUSTFLAGS="$(RUSTFLAGS) --print=native-static-libs" cargo build @CRAN_FLAGS@ --target=$(TARGET) --lib --release --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
+	export LIBRARY_PATH="$(LIBRARY_PATH);$(CURDIR)/$(TARGET_DIR)/libgcc_mock" && \
+	RUSTFLAGS="$(RUSTFLAGS) --print=native-static-libs" cargo build --jobs 2 --offline --target=$(TARGET) --lib --release --manifest-path=rust/Cargo.toml --target-dir=$(TARGET_DIR)
 
 	# Always clean up CARGOTMP
 	rm -Rf $(CARGOTMP);

--- a/inst/templates/Makevars.win.in
+++ b/inst/templates/Makevars.win.in
@@ -25,7 +25,7 @@ $(STATLIB):
 	fi
 
 	# Build the project using Cargo with additional flags
-	export CARGO_HOME=$(CURDIR)/$(CARGOTMP) && \
+	export CARGO_HOME=$(CARGOTMP) && \
 	export CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER="$(CARGO_LINKER)" && \
 	export LIBRARY_PATH="$(LIBRARY_PATH);$(CURDIR)/$(TARGET_DIR)/libgcc_mock" && \
 	RUSTFLAGS="$(RUSTFLAGS) --print=native-static-libs" cargo build @CRAN_FLAGS@ --target=$(TARGET) --lib @PROFILE@ --manifest-path=rust/Cargo.toml --target-dir=$(TARGET_DIR)

--- a/inst/templates/Makevars.win.in
+++ b/inst/templates/Makevars.win.in
@@ -5,7 +5,7 @@ LIBDIR = $(TARGET_DIR)/$(TARGET)/release
 STATLIB = $(LIBDIR)/lib{{{lib_name}}}.a
 PKG_LIBS = -L$(LIBDIR) -l{{{lib_name}}} -lws2_32 -ladvapi32 -luserenv -lbcrypt -lntdll
 
-all: C_clean
+all: $(SHLIB) C_clean
 
 $(SHLIB): $(STATLIB)
 

--- a/inst/templates/Makevars.win.in
+++ b/inst/templates/Makevars.win.in
@@ -7,6 +7,8 @@ PKG_LIBS = -L$(LIBDIR) -l{{{lib_name}}} -lws2_32 -ladvapi32 -luserenv -lbcrypt -
 
 all: $(SHLIB) rust_clean
 
+.PHONY: $(STATLIB)
+
 $(SHLIB): $(STATLIB)
 
 CARGOTMP = $(CURDIR)/.cargo

--- a/inst/templates/config.R
+++ b/inst/templates/config.R
@@ -1,0 +1,77 @@
+# check the packages MSRV first
+source("tools/msrv.R")
+
+# check DEBUG and NOT_CRAN environment variables
+env_debug <- Sys.getenv("DEBUG")
+env_not_cran <- Sys.getenv("NOT_CRAN")
+
+# check if the vendored zip file exists
+vendor_exists <- file.exists("src/rust/vendor.tar.xz")
+
+is_not_cran <- env_not_cran != ""
+is_debug <- env_debug != ""
+
+if (is_debug) {
+  # if we have DEBUG then we set not cran to true
+  # CRAN is always release build
+  is_not_cran <- TRUE
+  message("Creating DEBUG build.")
+}
+
+if (!is_not_cran) {
+  message("Building for CRAN.")
+}
+
+# we set cran flags only if NOT_CRAN is empty and if
+# the vendored crates are present.
+.cran_flags <- ifelse(
+  !is_not_cran && vendor_exists,
+  "-j 2 --offline",
+  ""
+)
+
+# when DEBUG env var is present we use `--debug` build
+.profile <- ifelse(is_debug, "", "--release")
+.clean_targets <- ifelse(is_debug, "", "$(TARGET_DIR)")
+
+# when we are using a debug build we need to use target/debug instead of target/release
+.libdir = ifelse(is_debug, "debug", "release")
+
+# read in the Makevars.in file
+is_windows <- .Platform[["OS.type"]] == "windows"
+
+# if windows we replace in the Makevars.win.in
+mv_fp <- ifelse(
+  is_windows,
+  "src/Makevars.win.in",
+  "src/Makevars.in"
+)
+
+# set the output file
+mv_ofp <- ifelse(
+  is_windows,
+  "src/Makevars.win",
+  "src/Makevars"
+)
+
+# delete the existing Makevars{.win}
+if (file.exists(mv_ofp)) {
+  message("Cleaning previous `", mv_ofp, "`.")
+  invisible(file.remove(mv_ofp))
+}
+
+# read as a single string
+mv_txt <- readLines(mv_fp)
+
+# replace placeholder values
+new_txt <- gsub("@CRAN_FLAGS@", .cran_flags, mv_txt) |>
+  gsub("@PROFILE@", .profile, x = _) |>
+  gsub("@CLEAN_TARGET@", .clean_targets, x = _) |>
+  gsub("@LIBDIR@", .libdir, x = _)
+
+message("Writing `", mv_ofp, "`.")
+con <- file(mv_ofp, open = "wb")
+writeLines(new_txt, con, sep = "\n")
+close(con)
+
+message("`tools/config.R` has finished.")

--- a/inst/templates/config.R
+++ b/inst/templates/config.R
@@ -35,7 +35,7 @@ if (!is_not_cran) {
 .clean_targets <- ifelse(is_debug, "", "$(TARGET_DIR)")
 
 # when we are using a debug build we need to use target/debug instead of target/release
-.libdir = ifelse(is_debug, "debug", "release")
+.libdir <- ifelse(is_debug, "debug", "release")
 
 # read in the Makevars.in file
 is_windows <- .Platform[["OS.type"]] == "windows"

--- a/inst/templates/configure
+++ b/inst/templates/configure
@@ -1,16 +1,3 @@
 #!/usr/bin/env sh
 : "${R_HOME=`R RHOME`}"
-"${R_HOME}/bin/Rscript" tools/msrv.R 
-
-# Set CRAN_FLAGS based on the NOT_CRAN value
-if [ "${NOT_CRAN}" != "true" ] && [ -f ./src/rust/vendor.tar.xz ]; then
-  export CRAN_FLAGS="-j 2 --offline"
-else
-  export CRAN_FLAGS=""
-fi
-
-# delete Makevars if it is present
-[ -f src/Makevars ] && rm src/Makevars
-
-# Substitute @CRAN_FLAGS@ in Makevars.in with the actual value of $CRAN_FLAGS
-sed -e "s|@CRAN_FLAGS@|$CRAN_FLAGS|" src/Makevars.in > src/Makevars
+"${R_HOME}/bin/Rscript" tools/config.R 

--- a/inst/templates/configure.win
+++ b/inst/templates/configure.win
@@ -1,15 +1,2 @@
 #!/usr/bin/env sh
-"${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" tools/msrv.R
-
-# Set CRAN_FLAGS based on the NOT_CRAN value
-if [ "${NOT_CRAN}" != "true" ] && [ -f ./src/rust/vendor.tar.xz ]; then
-  export CRAN_FLAGS="-j 2 --offline"
-else
-  export CRAN_FLAGS=""
-fi
-
-# delete Makevars.win if it is present
-[ -f src/Makevars.win ] && rm src/Makevars.win
-
-# Substitute @CRAN_FLAGS@ in Makevars.in with the actual value of $CRAN_FLAGS
-sed -e "s|@CRAN_FLAGS@|$CRAN_FLAGS|" src/Makevars.win.in > src/Makevars.win
+"${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" tools/config.R

--- a/tests/testthat/_snaps/cran-compliance.md
+++ b/tests/testthat/_snaps/cran-compliance.md
@@ -24,6 +24,6 @@
       5 paste          *.*.* 
       6 proc-macro2    *.*.* 
       7 quote          *.*.* 
-      8 syn            *.*.* 
+      8 syn            *.*.*
       9 unicode-ident  *.*.* 
 

--- a/tests/testthat/_snaps/use_extendr.md
+++ b/tests/testthat/_snaps/use_extendr.md
@@ -25,20 +25,7 @@
     Output
       #!/usr/bin/env sh
       : "${R_HOME=`R RHOME`}"
-      "${R_HOME}/bin/Rscript" tools/msrv.R 
-      
-      # Set CRAN_FLAGS based on the NOT_CRAN value
-      if [ "${NOT_CRAN}" != "true" ] && [ -f ./src/rust/vendor.tar.xz ]; then
-        export CRAN_FLAGS="-j 2 --offline"
-      else
-        export CRAN_FLAGS=""
-      fi
-      
-      # delete Makevars if it is present
-      [ -f src/Makevars ] && rm src/Makevars
-      
-      # Substitute @CRAN_FLAGS@ in Makevars.in with the actual value of $CRAN_FLAGS
-      sed -e "s|@CRAN_FLAGS@|$CRAN_FLAGS|" src/Makevars.in > src/Makevars
+      "${R_HOME}/bin/Rscript" tools/config.R
 
 ---
 
@@ -46,20 +33,7 @@
       cat_file("configure.win")
     Output
       #!/usr/bin/env sh
-      "${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" tools/msrv.R
-      
-      # Set CRAN_FLAGS based on the NOT_CRAN value
-      if [ "${NOT_CRAN}" != "true" ] && [ -f ./src/rust/vendor.tar.xz ]; then
-        export CRAN_FLAGS="-j 2 --offline"
-      else
-        export CRAN_FLAGS=""
-      fi
-      
-      # delete Makevars.win if it is present
-      [ -f src/Makevars.win ] && rm src/Makevars.win
-      
-      # Substitute @CRAN_FLAGS@ in Makevars.in with the actual value of $CRAN_FLAGS
-      sed -e "s|@CRAN_FLAGS@|$CRAN_FLAGS|" src/Makevars.win.in > src/Makevars.win
+      "${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" tools/config.R
 
 ---
 
@@ -218,7 +192,7 @@
       cat_file("src", "Makevars.in")
     Output
       TARGET_DIR = ./rust/target
-      LIBDIR = $(TARGET_DIR)/release
+      LIBDIR = $(TARGET_DIR)/@LIBDIR@
       STATLIB = $(LIBDIR)/libtestpkg.a
       PKG_LIBS = -L$(LIBDIR) -ltestpkg
       
@@ -251,13 +225,13 @@
       
       	export CARGO_HOME=$(CARGOTMP) && \
       	export PATH="$(PATH):$(HOME)/.cargo/bin" && \
-      	RUSTFLAGS="$(RUSTFLAGS) --print=native-static-libs" cargo build @CRAN_FLAGS@ --lib --release --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
+      	RUSTFLAGS="$(RUSTFLAGS) --print=native-static-libs" cargo build @CRAN_FLAGS@ --lib @PROFILE@ --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
       
       	# Always clean up CARGOTMP
       	rm -Rf $(CARGOTMP);
       
       rust_clean:
-      	rm -Rf $(CARGOTMP) $(VENDOR_DIR) $(TARGET_DIR)
+      	rm -Rf $(CARGOTMP) $(VENDOR_DIR) @CLEAN_TARGET@
       
       clean:
       	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS) $(TARGET_DIR)
@@ -284,7 +258,7 @@
       TARGET = $(subst 64,x86_64,$(subst 32,i686,$(WIN)))-pc-windows-gnu
       
       TARGET_DIR = ./rust/target
-      LIBDIR = $(TARGET_DIR)/$(TARGET)/release
+      LIBDIR = $(TARGET_DIR)/$(TARGET)/@LIBDIR@
       STATLIB = $(LIBDIR)/libtestpkg.a
       PKG_LIBS = -L$(LIBDIR) -ltestpkg -lws2_32 -ladvapi32 -luserenv -lbcrypt -lntdll
       
@@ -293,19 +267,12 @@
       $(SHLIB): $(STATLIB)
       
       CARGOTMP = $(CURDIR)/.cargo
+      VENDOR_DIR = vendor
       
       $(STATLIB):
       	mkdir -p $(TARGET_DIR)/libgcc_mock
-      	# `rustc` adds `-lgcc_eh` flags to the compiler, but Rtools' GCC doesn't have
-      	# `libgcc_eh` due to the compilation settings. So, in order to please the
-      	# compiler, we need to add empty `libgcc_eh` to the library search paths.
-      	#
-      	# For more details, please refer to
-      	# https://github.com/r-windows/rtools-packages/blob/2407b23f1e0925bbb20a4162c963600105236318/mingw-w64-gcc/PKGBUILD#L313-L316
       	touch $(TARGET_DIR)/libgcc_mock/libgcc_eh.a
       
-      	# When the NOT_CRAN flag is *not* set, the vendor.tar.xz, if present,
-      	# is unzipped and used for offline compilation.
       	if [ "$(NOT_CRAN)" != "true" ]; then \
       		if [ -f ./rust/vendor.tar.xz ]; then \
       			tar xf rust/vendor.tar.xz && \
@@ -315,10 +282,10 @@
       	fi
       
       	# Build the project using Cargo with additional flags
-      	export CARGO_HOME=$(CARGOTMP) && \
+      	export CARGO_HOME=$(CURDIR)/$(CARGOTMP) && \
       	export CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER="$(CARGO_LINKER)" && \
-      	export LIBRARY_PATH="$${LIBRARY_PATH};$(CURDIR)/$(TARGET_DIR)/libgcc_mock" && \
-      	RUSTFLAGS="$(RUSTFLAGS) --print=native-static-libs" cargo build @CRAN_FLAGS@ --target=$(TARGET) --lib --release --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
+      	export LIBRARY_PATH="$(LIBRARY_PATH);$(CURDIR)/$(TARGET_DIR)/libgcc_mock" && \
+      	RUSTFLAGS="$(RUSTFLAGS) --print=native-static-libs" cargo build --jobs 2 --offline --target=$(TARGET) --lib --release --manifest-path=rust/Cargo.toml --target-dir=$(TARGET_DIR)
       
       	# Always clean up CARGOTMP
       	rm -Rf $(CARGOTMP);
@@ -347,6 +314,7 @@
       publish = false
       version = '0.1.0'
       edition = '2021'
+      rust-version = '1.68.0'
       
       [lib]
       crate-type = [ 'staticlib' ]
@@ -396,6 +364,7 @@
       > File 'src/testpkg.wrap-win.def' already exists. Skip writing the file.
       > File 'R/extendr-wrappers.R' already exists. Skip writing the file.
       > File 'tools/msrv.R' already exists. Skip writing the file.
+      > File 'tools/config.R' already exists. Skip writing the file.
       > File 'configure' already exists. Skip writing the file.
       > File 'configure.win' already exists. Skip writing the file.
       v Finished configuring extendr for package testpkg.wrap.
@@ -415,6 +384,7 @@
       v Writing 'src/testpkg-win.def'
       > File 'R/extendr-wrappers.R' already exists. Skip writing the file.
       v Writing 'tools/msrv.R'
+      v Writing 'tools/config.R'
       v Writing 'configure'
       v Writing 'configure.win'
       v Finished configuring extendr for package testpkg.
@@ -430,6 +400,7 @@
       publish = false
       version = '0.1.0'
       edition = '2021'
+      rust-version = '1.68.0'
       
       [lib]
       crate-type = [ 'staticlib' ]
@@ -444,7 +415,7 @@
       cat_file("src", "Makevars.in")
     Output
       TARGET_DIR = ./rust/target
-      LIBDIR = $(TARGET_DIR)/release
+      LIBDIR = $(TARGET_DIR)/@LIBDIR@
       STATLIB = $(LIBDIR)/libbar.a
       PKG_LIBS = -L$(LIBDIR) -lbar
       
@@ -477,13 +448,13 @@
       
       	export CARGO_HOME=$(CARGOTMP) && \
       	export PATH="$(PATH):$(HOME)/.cargo/bin" && \
-      	RUSTFLAGS="$(RUSTFLAGS) --print=native-static-libs" cargo build @CRAN_FLAGS@ --lib --release --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
+      	RUSTFLAGS="$(RUSTFLAGS) --print=native-static-libs" cargo build @CRAN_FLAGS@ --lib @PROFILE@ --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
       
       	# Always clean up CARGOTMP
       	rm -Rf $(CARGOTMP);
       
       rust_clean:
-      	rm -Rf $(CARGOTMP) $(VENDOR_DIR) $(TARGET_DIR)
+      	rm -Rf $(CARGOTMP) $(VENDOR_DIR) @CLEAN_TARGET@
       
       clean:
       	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS) $(TARGET_DIR)

--- a/tests/testthat/_snaps/use_extendr.md
+++ b/tests/testthat/_snaps/use_extendr.md
@@ -198,6 +198,8 @@
       
       all: $(SHLIB) rust_clean
       
+      .PHONY: $(STATLIB)
+      
       $(SHLIB): $(STATLIB)
       
       CARGOTMP = $(CURDIR)/.cargo
@@ -263,6 +265,8 @@
       PKG_LIBS = -L$(LIBDIR) -ltestpkg -lws2_32 -ladvapi32 -luserenv -lbcrypt -lntdll
       
       all: $(SHLIB) rust_clean
+      
+      .PHONY: $(STATLIB)
       
       $(SHLIB): $(STATLIB)
       
@@ -420,6 +424,8 @@
       PKG_LIBS = -L$(LIBDIR) -lbar
       
       all: $(SHLIB) rust_clean
+      
+      .PHONY: $(STATLIB)
       
       $(SHLIB): $(STATLIB)
       

--- a/tests/testthat/_snaps/use_extendr.md
+++ b/tests/testthat/_snaps/use_extendr.md
@@ -285,13 +285,13 @@
       	export CARGO_HOME=$(CURDIR)/$(CARGOTMP) && \
       	export CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER="$(CARGO_LINKER)" && \
       	export LIBRARY_PATH="$(LIBRARY_PATH);$(CURDIR)/$(TARGET_DIR)/libgcc_mock" && \
-      	RUSTFLAGS="$(RUSTFLAGS) --print=native-static-libs" cargo build --jobs 2 --offline --target=$(TARGET) --lib --release --manifest-path=rust/Cargo.toml --target-dir=$(TARGET_DIR)
+      	RUSTFLAGS="$(RUSTFLAGS) --print=native-static-libs" cargo build @CRAN_FLAGS@ --target=$(TARGET) --lib @PROFILE@ --manifest-path=rust/Cargo.toml --target-dir=$(TARGET_DIR)
       
       	# Always clean up CARGOTMP
       	rm -Rf $(CARGOTMP);
       
       rust_clean:
-      	rm -Rf $(CARGOTMP) $(VENDOR_DIR) $(TARGET_DIR)
+      	rm -Rf $(CARGOTMP) $(VENDOR_DIR) @CLEAN_TARGET@
       
       clean:
       	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS) $(TARGET_DIR)
@@ -314,7 +314,7 @@
       publish = false
       version = '0.1.0'
       edition = '2021'
-      rust-version = '1.68.0'
+      rust-version = '1.65'
       
       [lib]
       crate-type = [ 'staticlib' ]
@@ -400,7 +400,7 @@
       publish = false
       version = '0.1.0'
       edition = '2021'
-      rust-version = '1.68.0'
+      rust-version = '1.65'
       
       [lib]
       crate-type = [ 'staticlib' ]

--- a/tests/testthat/_snaps/use_extendr.md
+++ b/tests/testthat/_snaps/use_extendr.md
@@ -282,7 +282,7 @@
       	fi
       
       	# Build the project using Cargo with additional flags
-      	export CARGO_HOME=$(CURDIR)/$(CARGOTMP) && \
+      	export CARGO_HOME=$(CARGOTMP) && \
       	export CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER="$(CARGO_LINKER)" && \
       	export LIBRARY_PATH="$(LIBRARY_PATH);$(CURDIR)/$(TARGET_DIR)/libgcc_mock" && \
       	RUSTFLAGS="$(RUSTFLAGS) --print=native-static-libs" cargo build @CRAN_FLAGS@ --target=$(TARGET) --lib @PROFILE@ --manifest-path=rust/Cargo.toml --target-dir=$(TARGET_DIR)

--- a/tests/testthat/_snaps/use_extendr.md
+++ b/tests/testthat/_snaps/use_extendr.md
@@ -14,6 +14,7 @@
     Output
       ^src/\.cargo$
       ^src/rust/vendor$
+      ^src/rust/target$
       ^src/Makevars$
       ^src/Makevars\.win$
 
@@ -221,7 +222,7 @@
       STATLIB = $(LIBDIR)/libtestpkg.a
       PKG_LIBS = -L$(LIBDIR) -ltestpkg
       
-      all: C_clean
+      all: $(SHLIB) rust_clean
       
       $(SHLIB): $(STATLIB)
       
@@ -255,11 +256,11 @@
       	# Always clean up CARGOTMP
       	rm -Rf $(CARGOTMP);
       
-      C_clean:
-      	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS)
+      rust_clean:
+      	rm -Rf $(CARGOTMP) $(VENDOR_DIR) $(TARGET_DIR)
       
       clean:
-      	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS) $(TARGET_DIR) $(VENDOR_DIR)
+      	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS) $(TARGET_DIR)
 
 ---
 
@@ -287,7 +288,7 @@
       STATLIB = $(LIBDIR)/libtestpkg.a
       PKG_LIBS = -L$(LIBDIR) -ltestpkg -lws2_32 -ladvapi32 -luserenv -lbcrypt -lntdll
       
-      all: C_clean
+      all: $(SHLIB) rust_clean
       
       $(SHLIB): $(STATLIB)
       
@@ -322,8 +323,8 @@
       	# Always clean up CARGOTMP
       	rm -Rf $(CARGOTMP);
       
-      C_clean:
-      	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS)
+      rust_clean:
+      	rm -Rf $(CARGOTMP) $(VENDOR_DIR) $(TARGET_DIR)
       
       clean:
       	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS) $(TARGET_DIR)
@@ -447,7 +448,7 @@
       STATLIB = $(LIBDIR)/libbar.a
       PKG_LIBS = -L$(LIBDIR) -lbar
       
-      all: C_clean
+      all: $(SHLIB) rust_clean
       
       $(SHLIB): $(STATLIB)
       
@@ -481,9 +482,9 @@
       	# Always clean up CARGOTMP
       	rm -Rf $(CARGOTMP);
       
-      C_clean:
-      	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS)
+      rust_clean:
+      	rm -Rf $(CARGOTMP) $(VENDOR_DIR) $(TARGET_DIR)
       
       clean:
-      	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS) $(TARGET_DIR) $(VENDOR_DIR)
+      	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS) $(TARGET_DIR)
 

--- a/tests/testthat/test-clean.R
+++ b/tests/testthat/test-clean.R
@@ -9,6 +9,8 @@ test_that("rextendr::clean() removes cargo target directory & binaries", {
   use_extendr()
   document()
 
+  # manually run cargo check here to regenerate the target directory
+  system("cargo check --manifest-path=src/rust/Cargo.toml")
   expect_equal(length(dir("src", pattern = "testpkg\\..*")), 1)
   expect_true(dir.exists(file.path("src", "rust", "target")))
 

--- a/tests/testthat/test-clean.R
+++ b/tests/testthat/test-clean.R
@@ -9,8 +9,6 @@ test_that("rextendr::clean() removes cargo target directory & binaries", {
   use_extendr()
   document()
 
-  # manually run cargo check here to regenerate the target directory
-  system("cargo check --manifest-path=src/rust/Cargo.toml")
   expect_equal(length(dir("src", pattern = "testpkg\\..*")), 1)
   expect_true(dir.exists(file.path("src", "rust", "target")))
 


### PR DESCRIPTION
R 4.5 a new check was introduces that identifies undesirable C function calls

https://github.com/r-devel/r-svn/blob/5695e158124051562158767089a55de80e7da452/src/library/tools/R/check.R#L3953-L3971

This has affected 24 packages on CRAN a good number of which use extendr. 

Inspiration was taken from https://github.com/r-rust/hellorust/blob/9a3ab01fd7ce6b3e5ee24d5af5e8ca3b28abd71f/src/Makevars#L7

closes https://github.com/extendr/rextendr/issues/418
sneaks in a resolution and closes https://github.com/extendr/rextendr/issues/375

