### PR TITLE
Remove spaces in `mask_any_version()` to enhance test robustness.

### DIFF
--- a/tests/testthat/_snaps/cran-compliance.md
+++ b/tests/testthat/_snaps/cran-compliance.md
@@ -17,13 +17,13 @@
       # A tibble: 9 x 2
         crate          version
         <chr>          <chr>  
-      1 extendr-api    *.*.*  
-      2 extendr-macros *.*.*  
-      3 libR-sys       *.*.*  
-      4 once_cell      *.*.* 
-      5 paste          *.*.* 
-      6 proc-macro2    *.*.* 
-      7 quote          *.*.* 
-      8 syn            *.*.* 
-      9 unicode-ident  *.*.* 
+      1 extendr-api    *.*.*
+      2 extendr-macros *.*.*
+      3 libR-sys       *.*.*
+      4 once_cell      *.*.*
+      5 paste          *.*.*
+      6 proc-macro2    *.*.*
+      7 quote          *.*.*
+      8 syn            *.*.*
+      9 unicode-ident  *.*.*
 

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -121,7 +121,7 @@ skip_if_opted_out_of_dev_tests <- function() {
 mask_any_version <- function(snapshot_lines) {
   stringi::stri_replace_all_regex(
     snapshot_lines,
-    "\\d+\\.\\d+\\.\\d+(?:\\.\\d+)?",
+    "\\d+\\.\\d+\\.\\d+(?:\\.\\d+)?\\s*",
     "*.*.*"
   )
 }


### PR DESCRIPTION
When running `check`, the `test-cran-compliance` may fail due to inconsistencies between the package list and the snapshot, caused by an extra space in the package version information.

This pull request includes a minor change to the `tests/testthat/helper.R` file. The change updates the regular expression in the `mask_any_version` function to allow for optional whitespace after the version number.

* `tests/testthat/helper.R`: Modified the regular expression in the `mask_any_version` function to include optional whitespace after the version number.