### PR TITLE
fix: remove makevars.ucrt template and cargo_linker in makevars.win template

### DIFF
--- a/inst/templates/Makevars.ucrt
+++ b/inst/templates/Makevars.ucrt
@@ -1,5 +1,0 @@
-# Rtools42 doesn't have the linker in the location that cargo expects, so we
-# need to overwrite it via configuration.
-CARGO_LINKER = x86_64-w64-mingw32.static.posix-gcc.exe
-
-include Makevars.win

--- a/inst/templates/Makevars.win.in
+++ b/inst/templates/Makevars.win.in
@@ -28,7 +28,6 @@ $(STATLIB):
 
 	# Build the project using Cargo with additional flags
 	export CARGO_HOME=$(CARGOTMP) && \
-	export CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER="$(CARGO_LINKER)" && \
 	export LIBRARY_PATH="$(LIBRARY_PATH);$(CURDIR)/$(TARGET_DIR)/libgcc_mock" && \
 	RUSTFLAGS="$(RUSTFLAGS) --print=native-static-libs" cargo build @CRAN_FLAGS@ --target=$(TARGET) --lib @PROFILE@ --manifest-path=rust/Cargo.toml --target-dir=$(TARGET_DIR)
 


### PR DESCRIPTION
This follow-up PR to #414 removes leftover elements:

Deletes the makevars.ucrt template.
Removes the Cargo linker environment variable previously set in makevars.ucrt, which was causing compilation errors on CRAN when makevars.ucrt was removed.