### PR TITLE
feat: add webR support

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # rextendr (development version)
 
+* Adds [WebR](https://docs.r-wasm.org/webr/latest/) support out of the box for all extendr packages.
+  * Note that not all Rust crates are wasm compatible. This change only enables the package to build in the `wasm32-unknown-emscripten` target. It does not guarantee all dependencies will compile.
 * Addresses new CRAN check in R 4.5+ adding warning for `_abort` usage
 * Removes `Makevars.ucrt` as R versions < 4.1 are not supported by extendr <https://github.com/extendr/rextendr/pull/414> 
 * `purrr` has been replaced with [`R/standalone-purrr.R`](https://github.com/r-lib/rlang/blob/main/R/standalone-purrr.R) removing `purrr` from `Imports` <https://github.com/extendr/rextendr/pull/408>

--- a/inst/templates/Makevars.in
+++ b/inst/templates/Makevars.in
@@ -34,7 +34,7 @@ $(STATLIB):
 
 	export CARGO_HOME=$(CARGOTMP) && \
 	export PATH="$(PATH):$(HOME)/.cargo/bin" && \
-	RUSTFLAGS="$(RUSTFLAGS) --print=native-static-libs" cargo build @CRAN_FLAGS@ --lib @PROFILE@ --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
+	RUSTFLAGS="$(RUSTFLAGS) --print=native-static-libs" cargo build @CRAN_FLAGS@ --lib @PROFILE@ --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR) @TARGET@
 
 	# Always clean up CARGOTMP
 	rm -Rf $(CARGOTMP);

--- a/inst/templates/config.R
+++ b/inst/templates/config.R
@@ -48,22 +48,15 @@ if (is_wasm) {
   message("Building for WebR")
 }
 
-# if so, our target_lib path is specified, otherwise null
-# this will be used to fill out the LIBDIR env var for Makevars.in
-target_libpath <- if (is_wasm) {
-  paste0(webr_target, "/")
-} else {
-  NULL
-}
-
 # we check if we are making a debug build or not
 # if so, the LIBDIR environment variable becomes:
 # LIBDIR = $(TARGET_DIR)/{wasm32-unknown-emscripten}/debug
-.libdir <- if (is_debug) {
-  paste0(target_libpath, "debug")
-} else {
-  paste0(target_libpath, "release")
-}
+# this will be used to fill out the LIBDIR env var for Makevars.in
+target_libpath <- if (is_wasm) "wasm32-unknown-emscripten" else NULL
+cfg <- if (is_debug) "debug" else "release"
+
+# used to replace @LIBDIR@
+.libdir <- paste(c(target_libpath, cfg), collapse = "/")
 
 # use this to replace @TARGET@
 # we specify the target _only_ on webR

--- a/inst/templates/config.R
+++ b/inst/templates/config.R
@@ -1,3 +1,6 @@
+# Note: Any variables prefixed with `.` are used for text
+# replacement in the Makevars.in and Makevars.win.in
+
 # check the packages MSRV first
 source("tools/msrv.R")
 
@@ -34,8 +37,25 @@ if (!is_not_cran) {
 .profile <- ifelse(is_debug, "", "--release")
 .clean_targets <- ifelse(is_debug, "", "$(TARGET_DIR)")
 
+# check for webR
+is_wasm <- R.version$platform == "wasm32-unknown-emscripten"
+
+if (is_wasm) {
+  message("Building for webR")
+}
+
+# use this to replace @TARGET@
+.target <- ifelse(is_wasm, "--target=wasm32-unknown-emscripten", "")
+
 # when we are using a debug build we need to use target/debug instead of target/release
-.libdir <- ifelse(is_debug, "debug", "release")
+# if we're in wasm then we use wasm32-unknown-emscripten prefix
+.libdir <- if (is_wasm) {
+  "wasm32-unknown-emscripten/release"
+} else if (is_debug) {
+  "debug"
+} else {
+  "release"
+}
 
 # read in the Makevars.in file
 is_windows <- .Platform[["OS.type"]] == "windows"

--- a/inst/templates/config.R
+++ b/inst/templates/config.R
@@ -45,16 +45,14 @@ if (is_wasm) {
 }
 
 # use this to replace @TARGET@
-.target <- ifelse(is_wasm, "--target=wasm32-unknown-emscripten", "")
+.target <- ifelse(is_wasm, "--target=wasm32-unknown-emscripten/", "")
 
 # when we are using a debug build we need to use target/debug instead of target/release
 # if we're in wasm then we use wasm32-unknown-emscripten prefix
-.libdir <- if (is_wasm) {
-  "wasm32-unknown-emscripten/release"
-} else if (is_debug) {
-  "debug"
+.libdir <- if (is_debug) {
+  paste0(.target, "debug")
 } else {
-  "release"
+  paste0(.target, "release")
 }
 
 # read in the Makevars.in file

--- a/inst/templates/config.R
+++ b/inst/templates/config.R
@@ -87,7 +87,8 @@ mv_txt <- readLines(mv_fp)
 new_txt <- gsub("@CRAN_FLAGS@", .cran_flags, mv_txt) |>
   gsub("@PROFILE@", .profile, x = _) |>
   gsub("@CLEAN_TARGET@", .clean_targets, x = _) |>
-  gsub("@LIBDIR@", .libdir, x = _)
+  gsub("@LIBDIR@", .libdir, x = _) |>
+  gsub("@TARGET@", .target, x = _)
 
 message("Writing `", mv_ofp, "`.")
 con <- file(mv_ofp, open = "wb")

--- a/tests/testthat/_snaps/use_extendr.md
+++ b/tests/testthat/_snaps/use_extendr.md
@@ -227,7 +227,7 @@
       
       	export CARGO_HOME=$(CARGOTMP) && \
       	export PATH="$(PATH):$(HOME)/.cargo/bin" && \
-      	RUSTFLAGS="$(RUSTFLAGS) --print=native-static-libs" cargo build @CRAN_FLAGS@ --lib @PROFILE@ --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
+      	RUSTFLAGS="$(RUSTFLAGS) --print=native-static-libs" cargo build @CRAN_FLAGS@ --lib @PROFILE@ --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR) @TARGET@
       
       	# Always clean up CARGOTMP
       	rm -Rf $(CARGOTMP);
@@ -453,7 +453,7 @@
       
       	export CARGO_HOME=$(CARGOTMP) && \
       	export PATH="$(PATH):$(HOME)/.cargo/bin" && \
-      	RUSTFLAGS="$(RUSTFLAGS) --print=native-static-libs" cargo build @CRAN_FLAGS@ --lib @PROFILE@ --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
+      	RUSTFLAGS="$(RUSTFLAGS) --print=native-static-libs" cargo build @CRAN_FLAGS@ --lib @PROFILE@ --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR) @TARGET@
       
       	# Always clean up CARGOTMP
       	rm -Rf $(CARGOTMP);


### PR DESCRIPTION
This PR modifies `tools/config.R` and `Makevars.in` to add support for webR. This approach was first verified by modifying b64. [See the wasm builds in R-universe](https://extendr.r-universe.dev/b64).

This PR makes it possible by detecting if the build environment is wasm. If so, we set `--target wasm32-unknown-emscripten` as well as adding the appropriate prefix to the `LIBDIR` environment variable.