### PR TITLE
fix: revert OS specific logic for `rust_sitrep()`

### DIFF
--- a/R/rust_sitrep.R
+++ b/R/rust_sitrep.R
@@ -115,15 +115,9 @@ rustup_toolchain_target <- function() {
   # ----------------
   #
   # stable-x86_64-pc-windows-msvc (default)
-  host <- if (is_osx() && is.na(try_exec_cmd("rustup", "show"))) {
-    output <- try_exec_cmd("rustc", c("--version", "--verbose"))
-    host_index <- grep("host:", output)
-    gsub("host: ", "", output[host_index])
-  } else {
-    try_exec_cmd("rustup", "show") |>
-      stringi::stri_sub(from = 15L) |>
-      vctrs::vec_slice(1L)
-  }
+  host <- try_exec_cmd("rustup", "show") |>
+    stringi::stri_sub(from = 15L) |>
+    vctrs::vec_slice(1L)
 
   # > rustup toolchain list
   # stable-x86_64-pc-windows-msvc


### PR DESCRIPTION
`rust_sitrep()` no longer need osx specific logic as per rustup 1.28.

The previous behavior (#416) was fixed in rustup 1.28. Now for macOS we have:

```
➜  rextendr git:(albersonmiranda/issue447) ✗ rustup show
Default host: aarch64-apple-darwin
rustup home:  /Users/albersonmiranda/.rustup

installed toolchains
--------------------
stable-aarch64-apple-darwin
1.77-aarch64-apple-darwin
1.81-aarch64-apple-darwin

active toolchain
----------------
no active toolchain
```

which is the same behavior we get in Linux and Windows.

Reverting osx specific logic we've got expected results:

```
r$> rust_sitrep()
Rust infrastructure sitrep:
✔ "rustup": 1.28.2 (2025-04-28)
✔ "cargo": 1.87.0 (Homebrew)
ℹ host: aarch64-apple-darwin
ℹ toolchains: stable-aarch64-apple-darwin, 1.77-aarch64-apple-darwin, and 1.81-aarch64-apple-darwin
! One of these toolchains should be default: stable-aarch64-apple-darwin, 1.77-aarch64-apple-darwin, and 1.81-aarch64-apple-darwin
ℹ Run e.g. `rustup default stable-aarch64-apple-darwin`
```

Fixes #447