### PR TITLE
chore: clean up vendor dir after `vendor_pkgs()`

### DIFF
--- a/R/cran-compliance.R
+++ b/R/cran-compliance.R
@@ -119,8 +119,10 @@ vendor_pkgs <- function(path = ".", quiet = FALSE, overwrite = NULL) {
   }
 
   # clean up vendor directory
-  cli::cli_alert_info("Removing {.path src/rust/vendor} directory")
-  unlink(file.path(src_dir, "vendor"), recursive = TRUE)
+  if (dir.exists(file.path(src_dir, "vendor"))) {
+    cli::cli_alert_info("Removing {.path src/rust/vendor} directory")
+    unlink(file.path(src_dir, "vendor"), recursive = TRUE)
+  }
 
   # return packages and versions invisibly
   invisible(res)

--- a/R/cran-compliance.R
+++ b/R/cran-compliance.R
@@ -118,6 +118,10 @@ vendor_pkgs <- function(path = ".", quiet = FALSE, overwrite = NULL) {
     )
   }
 
+  # clean up vendor directory
+  cli::cli_alert_info("Removing {.path src/rust/vendor} directory")
+  unlink(file.path(src_dir, "vendor"), recursive = TRUE)
+
   # return packages and versions invisibly
   invisible(res)
 }


### PR DESCRIPTION
This PR adds a clean up step at the end of vendoring process to remove `src/rust/vendor` dir.

Closes #452