### PR TITLE
chore: update Cargo.toml generation

### DIFF
--- a/R/use_extendr.R
+++ b/R/use_extendr.R
@@ -136,7 +136,11 @@ use_extendr <- function(
       `rust-version` = "1.65"
     ),
     lib = list(`crate-type` = array("staticlib", 1), name = lib_name),
-    dependencies = list(`extendr-api` = "*")
+    dependencies = list(`extendr-api` = "*"),
+    `profile.release` = list(
+      lto = "true",
+      `codegen-units` = 1
+    )
   )
 
   use_rextendr_template(


### PR DESCRIPTION
This PR follows #461.

As required for wasm build, adds the following lines to Cargo.toml template in `use_extendr()`:

```
[profile.release]
lto = true
codegen-units = 1
```

Closes #463.