### PR TITLE
feat: add configure arguments to enable features or profiles during installation

### DIFF
--- a/R/use_extendr.R
+++ b/R/use_extendr.R
@@ -201,7 +201,8 @@ use_extendr <- function(
     "config.R",
     save_as = file.path("tools", "config.R"),
     quiet = quiet,
-    overwrite = overwrite
+    overwrite = overwrite,
+    data = list(pkg_name = pkg_name)
   )
 
   # add configure and configure.win templates

--- a/inst/templates/Makevars.in
+++ b/inst/templates/Makevars.in
@@ -30,7 +30,7 @@ $(STATLIB):
 
 	export CARGO_HOME=$(CARGOTMP) && \
 	export PATH="$(PATH):$(HOME)/.cargo/bin" && \
-	@PANIC_EXPORTS@RUSTFLAGS="$(RUSTFLAGS) --print=native-static-libs" cargo build @CRAN_FLAGS@ --lib @PROFILE@ --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR) @TARGET@
+	@PANIC_EXPORTS@RUSTFLAGS="$(RUSTFLAGS) --print=native-static-libs" cargo build @CRAN_FLAGS@ --lib @PROFILE@ --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR) @TARGET@ @FEATURES@
 
 	# Always clean up CARGOTMP
 	rm -Rf $(CARGOTMP);

--- a/inst/templates/Makevars.win.in
+++ b/inst/templates/Makevars.win.in
@@ -27,7 +27,7 @@ $(STATLIB):
 	# Build the project using Cargo with additional flags
 	export CARGO_HOME=$(CARGOTMP) && \
 	export LIBRARY_PATH="$(LIBRARY_PATH);$(CURDIR)/$(TARGET_DIR)/libgcc_mock" && \
-	RUSTFLAGS="$(RUSTFLAGS) --print=native-static-libs" cargo build @CRAN_FLAGS@ --target=$(TARGET) --lib @PROFILE@ --manifest-path=rust/Cargo.toml --target-dir=$(TARGET_DIR)
+	RUSTFLAGS="$(RUSTFLAGS) --print=native-static-libs" cargo build @CRAN_FLAGS@ --target=$(TARGET) --lib @PROFILE@ --manifest-path=rust/Cargo.toml --target-dir=$(TARGET_DIR) @FEATURES@
 
 	# Always clean up CARGOTMP
 	rm -Rf $(CARGOTMP);

--- a/inst/templates/configure
+++ b/inst/templates/configure
@@ -1,3 +1,29 @@
 #!/usr/bin/env sh
+
+# Initialize variables
+FEATURES=""
+PROFILE=""
+
+# Parse and validate configure arguments
+for arg in "$@"; do
+  case $arg in
+    --with-features=*)
+      value="${arg#*=}"
+      if [ -n "$FEATURES" ]; then
+        FEATURES="${FEATURES},${value}"
+      else
+        FEATURES="${value}"
+      fi
+      ;;
+    --with-profile=*)
+      PROFILE="${arg#*=}"
+      ;;
+    *)
+      echo "configure: error: unknown argument: $arg" >&2
+      exit 1
+      ;;
+  esac
+done
+
 : "${R_HOME=`R RHOME`}"
-"${R_HOME}/bin/Rscript" tools/config.R 
+"${R_HOME}/bin/Rscript" tools/config.R "${PROFILE}" "${FEATURES}"

--- a/inst/templates/configure.win
+++ b/inst/templates/configure.win
@@ -1,2 +1,26 @@
-#!/usr/bin/env sh
-"${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" tools/config.R
+# Initialize variables
+FEATURES=""
+PROFILE=""
+
+# Parse and validate configure arguments
+for arg in "$@"; do
+  case $arg in
+    --with-features=*)
+      value="${arg#*=}"
+      if [ -n "$FEATURES" ]; then
+        FEATURES="${FEATURES},${value}"
+      else
+        FEATURES="${value}"
+      fi
+      ;;
+    --with-profile=*)
+      PROFILE="${arg#*=}"
+      ;;
+    *)
+      echo "configure.win: error: unknown argument: $arg" >&2
+      exit 1
+      ;;
+  esac
+done
+
+"${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" tools/config.R  "${PROFILE}" "${FEATURES}"

--- a/tests/testthat/_snaps/use_extendr.md
+++ b/tests/testthat/_snaps/use_extendr.md
@@ -12,6 +12,7 @@
     Code
       cat_file(".Rbuildignore")
     Output
+      ^\.vscode$
       ^src/\.cargo$
       ^src/rust/vendor$
       ^src/rust/target$
@@ -24,16 +25,66 @@
       cat_file("configure")
     Output
       #!/usr/bin/env sh
+      
+      # Initialize variables
+      FEATURES=""
+      PROFILE=""
+      
+      # Parse and validate configure arguments
+      for arg in "$@"; do
+        case $arg in
+          --with-features=*)
+            value="${arg#*=}"
+            if [ -n "$FEATURES" ]; then
+              FEATURES="${FEATURES},${value}"
+            else
+              FEATURES="${value}"
+            fi
+            ;;
+          --with-profile=*)
+            PROFILE="${arg#*=}"
+            ;;
+          *)
+            echo "configure: error: unknown argument: $arg" >&2
+            exit 1
+            ;;
+        esac
+      done
+      
       : "${R_HOME=`R RHOME`}"
-      "${R_HOME}/bin/Rscript" tools/config.R
+      "${R_HOME}/bin/Rscript" tools/config.R "${PROFILE}" "${FEATURES}"
 
 ---
 
     Code
       cat_file("configure.win")
     Output
-      #!/usr/bin/env sh
-      "${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" tools/config.R
+      # Initialize variables
+      FEATURES=""
+      PROFILE=""
+      
+      # Parse and validate configure arguments
+      for arg in "$@"; do
+        case $arg in
+          --with-features=*)
+            value="${arg#*=}"
+            if [ -n "$FEATURES" ]; then
+              FEATURES="${FEATURES},${value}"
+            else
+              FEATURES="${value}"
+            fi
+            ;;
+          --with-profile=*)
+            PROFILE="${arg#*=}"
+            ;;
+          *)
+            echo "configure.win: error: unknown argument: $arg" >&2
+            exit 1
+            ;;
+        esac
+      done
+      
+      "${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" tools/config.R  "${PROFILE}" "${FEATURES}"
 
 ---
 
@@ -223,7 +274,7 @@
       
       	export CARGO_HOME=$(CARGOTMP) && \
       	export PATH="$(PATH):$(HOME)/.cargo/bin" && \
-      	@PANIC_EXPORTS@RUSTFLAGS="$(RUSTFLAGS) --print=native-static-libs" cargo build @CRAN_FLAGS@ --lib @PROFILE@ --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR) @TARGET@
+      	@PANIC_EXPORTS@RUSTFLAGS="$(RUSTFLAGS) --print=native-static-libs" cargo build @CRAN_FLAGS@ --lib @PROFILE@ --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR) @TARGET@ @FEATURES@
       
       	# Always clean up CARGOTMP
       	rm -Rf $(CARGOTMP);
@@ -282,7 +333,7 @@
       	# Build the project using Cargo with additional flags
       	export CARGO_HOME=$(CARGOTMP) && \
       	export LIBRARY_PATH="$(LIBRARY_PATH);$(CURDIR)/$(TARGET_DIR)/libgcc_mock" && \
-      	RUSTFLAGS="$(RUSTFLAGS) --print=native-static-libs" cargo build @CRAN_FLAGS@ --target=$(TARGET) --lib @PROFILE@ --manifest-path=rust/Cargo.toml --target-dir=$(TARGET_DIR)
+      	RUSTFLAGS="$(RUSTFLAGS) --print=native-static-libs" cargo build @CRAN_FLAGS@ --target=$(TARGET) --lib @PROFILE@ --manifest-path=rust/Cargo.toml --target-dir=$(TARGET_DIR) @FEATURES@
       
       	# Always clean up CARGOTMP
       	rm -Rf $(CARGOTMP);
@@ -453,7 +504,7 @@
       
       	export CARGO_HOME=$(CARGOTMP) && \
       	export PATH="$(PATH):$(HOME)/.cargo/bin" && \
-      	@PANIC_EXPORTS@RUSTFLAGS="$(RUSTFLAGS) --print=native-static-libs" cargo build @CRAN_FLAGS@ --lib @PROFILE@ --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR) @TARGET@
+      	@PANIC_EXPORTS@RUSTFLAGS="$(RUSTFLAGS) --print=native-static-libs" cargo build @CRAN_FLAGS@ --lib @PROFILE@ --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR) @TARGET@ @FEATURES@
       
       	# Always clean up CARGOTMP
       	rm -Rf $(CARGOTMP);


### PR DESCRIPTION
This PR introduces two new configure arguments, `--with-features` and `--with-profile`, which allow enabling features or profiles during installation.

It also respects the environment variables `{pkg_name}_FEATURES` and `{pkg_name}_PROFILE`.