### PR TITLE
Remove invisible(NULL) from rust_sitrep and adjust docs

### DIFF
--- a/R/rust_sitrep.R
+++ b/R/rust_sitrep.R
@@ -2,7 +2,7 @@
 #'
 #' Prints out a detailed report on the state of Rust infrastructure on the host machine.
 #' @export
-#' @return Nothing
+#' @return NULL (invisibly)
 rust_sitrep <- function() {
   cargo_v <- get_version("cargo")
   cargo_msg <- if (is.na(cargo_v)) {
@@ -84,8 +84,6 @@ rust_sitrep <- function() {
   }
 
   cli::cli_inform(msgs)
-
-  invisible(NULL)
 }
 
 get_version <- function(cmd) {

--- a/man/rust_sitrep.Rd
+++ b/man/rust_sitrep.Rd
@@ -7,7 +7,7 @@
 rust_sitrep()
 }
 \value{
-Nothing
+NULL (invisibly)
 }
 \description{
 Prints out a detailed report on the state of Rust infrastructure on the host machine.


### PR DESCRIPTION
Dear all, I decided to create this PR to remove the final `invisible(NULL)` line from `rust_sitrep()`. I believe that line is redundant since the final call is to `cli::cli_inform` which calls `rlang::inform`, and `rlang::inform` already returns `invisible()` (which is equivalent to `invisible(NULL)`). 

I also slightly changed the docs to be slightly more specific. 

 