### PR TITLE
Wrap make_wrappers() in rust_source() with try_fetch for context on failure

### DIFF
--- a/R/source.R
+++ b/R/source.R
@@ -396,12 +396,21 @@ rust_source <- function(
   # generate R bindings for shared library
   wrapper_file <- file.path(the$build_dir, "target", "extendr_wrappers.R")
 
-  make_wrappers(
-    module_name = as_valid_rust_name(opts[["module_name"]]),
-    package_name = dll_info[["name"]],
-    outfile = wrapper_file,
-    use_symbols = FALSE,
-    quiet = quiet
+  rlang::try_fetch(
+    make_wrappers(
+      module_name = as_valid_rust_name(opts[["module_name"]]),
+      package_name = dll_info[["name"]],
+      outfile = wrapper_file,
+      use_symbols = FALSE,
+      quiet = quiet
+    ),
+    error = function(cnd) {
+      cli::cli_abort(
+        "Failed to generate wrapper functions.",
+        parent = cnd,
+        class = "rextendr_error"
+      )
+    }
   )
 
   source(wrapper_file, local = env)


### PR DESCRIPTION
## Summary

A failing `.Call("wrap__make_<mod>_wrappers")` inside `make_wrappers()` previously bubbled up as a bare R error with no rextendr context. This wraps the call in `rlang::try_fetch()` so the failure surfaces as a `rextendr_error` ("Failed to generate wrapper functions.") with the underlying condition chained via `parent`, matching the style already used for the `run_cargo()` invocation a few lines above.

This mirrors the pattern that the deprecated `register_extendr()` used to apply around `make_wrappers_externally()` — we just lost that bubbling on the dynamic-compilation path when the package path migrated to the `document` binary.

Affects everything that funnels through `rust_source()`:
- `rust_source()` / `rust_function()`
- `rust_eval()` (via `rust_eval_deferred()`)
- Knitr engines `eng_extendr` and `eng_extendrsrc`

Companion to #511, which tracks the related "warnings on success are silently dropped" gap.

## Test plan

- [ ] `R CMD check` passes
- [ ] Existing tests still pass
- [ ] Manually trigger a `make_wrappers` failure (e.g., mismatched `module_name` so `wrap__make_<mod>_wrappers` is not exported) and confirm the abort renders with the contextual rextendr message and the `parent` cause is shown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)