### PR TITLE
Disable codecov-commenter PR comments

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,7 +1,4 @@
-comment:
-  layout: "header, reach, files"
-  require_changes: true
-  behavior: "new" # Only post on new commits
+comment: false
 coverage:
   status:
     project:


### PR DESCRIPTION
## Summary

The `codecov-commenter` bot keeps posting on PRs despite repeated attempts to silence it. Codecov's documented way to disable the commenter is `comment: false` in `codecov.yml`. This replaces the existing `comment:` block (which was actually *configuring* the comment, not disabling it) with `comment: false`.

Coverage status checks (`project` and `patch` thresholds at 70% / 5%) are kept as-is — only the PR comment is disabled.

Reference: https://docs.codecov.com/docs/pull-request-comments#disabling-comments

## Test plan

- [ ] After merge, open a follow-up PR and confirm that `codecov-commenter` does not post a comment
- [ ] Confirm coverage status checks still appear and gate as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)