### PR TITLE
Print cargo errors in rust_source()

### DIFF
--- a/R/clean.R
+++ b/R/clean.R
@@ -45,12 +45,7 @@ clean <- function(path = ".", echo = TRUE) {
   args <- c(
     "clean",
     glue::glue("--manifest-path={manifest_path}"),
-    glue::glue("--target-dir={target_dir}"),
-    if (tty_has_colors()) {
-      "--color=always"
-    } else {
-      "--color=never"
-    }
+    glue::glue("--target-dir={target_dir}")
   )
 
   run_cargo(

--- a/R/helpers.r
+++ b/R/helpers.r
@@ -1,5 +1,3 @@
-tty_has_colors <- function() isTRUE(cli::num_ansi_colors() > 1L)
-
 get_cargo_envvars <- function() {
   if (identical(.Platform$OS.type, "windows")) {
     # On Windows, PATH to Rust toolchain should be set by the installer.

--- a/R/read_cargo_metadata.R
+++ b/R/read_cargo_metadata.R
@@ -44,11 +44,6 @@ read_cargo_metadata <- function(
     "--format-version=1",
     if (!dependencies) {
       "--no-deps"
-    },
-    if (tty_has_colors()) {
-      "--color=always"
-    } else {
-      "--color=never"
     }
   )
 

--- a/R/run_cargo.R
+++ b/R/run_cargo.R
@@ -46,6 +46,12 @@ run_cargo <- function(
   check_character(env, call = error_call, class = "rextendr_error")
   check_bool(parse_json, call = error_call, class = "rextendr_error")
 
+  if (isTRUE(cli::num_ansi_colors() > 1L)) {
+    args <- c(args, "--color=always")
+  } else {
+    args <- c(args, "--color=never")
+  }
+
   out <- processx::run(
     command = "cargo",
     args = args,
@@ -72,7 +78,7 @@ run_cargo <- function(
       jsonlite::parse_json(stdout, simplifyDataFrame = TRUE),
       error = function(cnd) {
         cli::cli_abort(
-          c("Failed to {.code stdout} as json:", " " = "{stdout}"),
+          c("Failed to parse {.code stdout} as json:", " " = "{stdout}"),
           parent = cnd,
           class = "rextendr_error"
         )

--- a/R/source.R
+++ b/R/source.R
@@ -648,9 +648,6 @@ check_extendr_fn_options <- function(
 
   nms <- names(extendr_fn_options)
 
-  # is valid name?
-  valid_names <- is_valid_rust_name(nms)
-
   # is known name?
   unknown_names <- setdiff(nms, c("r_name", "mod_name", "use_rng"))
   unknown_dev_names <- setdiff(unknown_names, "invisible")

--- a/R/source.R
+++ b/R/source.R
@@ -350,26 +350,11 @@ rust_source <- function(
     sprintf("--target=%s", specific_target),
     sprintf("--manifest-path=%s", file.path(the$build_dir, "Cargo.toml")),
     sprintf("--target-dir=%s", file.path(the$build_dir, "target")),
-    sprintf("--profile=%s", opts[["profile"]]),
-    "--message-format=json-diagnostic-rendered-ansi",
-    if (tty_has_colors()) {
-      "--color=always"
-    } else {
-      "--color=never"
-    }
+    sprintf("--profile=%s", opts[["profile"]])
   )
 
   # try running cargo command
-  rlang::try_fetch(
-    run_cargo(args, echo = echo, wd = NULL),
-    error = function(cnd) {
-      cli::cli_abort(
-        "Rust code could not be compiled successfully. Aborting.",
-        parent = cnd,
-        class = "rextendr_error"
-      )
-    }
-  )
+  run_cargo(args, echo = echo, wd = NULL)
 
   # load shared library
   libfilename <- as_rust_lib_file_name(paste0(
@@ -667,20 +652,13 @@ check_extendr_fn_options <- function(
   valid_names <- is_valid_rust_name(nms)
 
   # is known name?
-  unknown_names <- setdiff(
-    nms,
-    c("r_name", "mod_name", "use_rng")
-  )
-
-  unknown_dev_names <- setdiff(
-    unknown_names,
-    "invisible"
-  )
+  unknown_names <- setdiff(nms, c("r_name", "mod_name", "use_rng"))
+  unknown_dev_names <- setdiff(unknown_names, "invisible")
 
   if (length(unknown_dev_names) > 0L) {
     cli::cli_abort(
       c(
-        "Found unknown {.code extendr} function option{?s}: {.val {unknown_names}}.",
+        "Found unknown {.code extendr} function option{?s}: {.val {unknown_dev_names}}.",
         "i" = "These are not available on release or development versions of extendr."
       ),
       call = call,
@@ -697,66 +675,55 @@ check_extendr_fn_options <- function(
     )
   }
 
-  # check values
-  empty <- vector(mode = "logical", length = length(extendr_fn_options))
-  scalar <- vector(mode = "logical", length = length(extendr_fn_options))
-
-  for (i in seq_along(extendr_fn_options)) {
-    value <- extendr_fn_options[[i]]
-
-    # is substantive?
-    empty[i] <- rlang::is_na(value) ||
-      rlang::is_null(value) ||
-      rlang::is_empty(value) ||
-      !nzchar(value)
-
-    # is scalar?
-    scalar[i] <- length(value) == 1L
-  }
-
-  message <- "Found {.val {n_invalid_opts}} invalid {.code extendr} function option{?s}:"
-
-  if (!all(valid_names)) {
-    invalid_names <- nms[which(!valid_names)] # nolint: object_usage_linter
-    message <- c(
-      message,
-      x = "Unsupported name{?s}: {.val {invalid_names}}.",
-      i = "Option names should be valid rust names."
-    )
-  }
+  # is empty
+  empty <- vapply(
+    extendr_fn_options,
+    FUN = function(.x) {
+      rlang::is_na(.x) ||
+        rlang::is_null(.x) ||
+        rlang::is_empty(.x) ||
+        !nzchar(.x)
+    },
+    FUN.VALUE = logical(1)
+  )
 
   if (any(empty)) {
     null_values <- nms[which(empty)] # nolint: object_usage_linter
-    message <- c(
-      message,
-      x = "Null value{?s}: {.val {null_values}}.",
-      i = "{.code NULL} values are disallowed."
-    )
-  }
-
-  if (!all(scalar)) {
-    vector_values <- nms[which(!scalar)] # nolint: object_usage_linter
-    message <- c(
-      message,
-      x = "Vector value{?s}: {.val {vector_values}}.",
-      i = "Only scalars are allowed as option values."
-    )
-  }
-
-  n_invalid_opts <- sum(c(!valid_names, empty, !scalar))
-
-  if (n_invalid_opts > 0L) {
-    # sort to maintain order with previous version of rextendr
-    x_idx <- which(names(message) == "x")
-    i_idx <- which(names(message) == "i")
-    message <- message[c(1, x_idx, i_idx)]
-
     cli::cli_abort(
-      message,
+      c(
+        x = "Null value{?s}: {.val {null_values}}.",
+        i = "{.code NULL} values are disallowed."
+      ),
       call = call,
       class = "rextendr_error"
     )
   }
+
+  # check values
+  check_string(
+    extendr_fn_options[["r_name"]],
+    allow_null = TRUE,
+    call = call,
+    class = "rextendr_error"
+  )
+  check_string(
+    extendr_fn_options[["mod_name"]],
+    allow_null = TRUE,
+    call = call,
+    class = "rextendr_error"
+  )
+  check_bool(
+    extendr_fn_options[["use_rng"]],
+    allow_null = TRUE,
+    call = call,
+    class = "rextendr_error"
+  )
+  check_bool(
+    extendr_fn_options[["invisible"]],
+    allow_null = TRUE,
+    call = call,
+    class = "rextendr_error"
+  )
 
   invisible(extendr_fn_options)
 }

--- a/R/use_crate.R
+++ b/R/use_crate.R
@@ -89,12 +89,7 @@ use_crate <- function(
     crate,
     features,
     git,
-    optional,
-    if (tty_has_colors()) {
-      "--color=always"
-    } else {
-      "--color=never"
-    }
+    optional
   )
 
   run_cargo(

--- a/tests/testthat/test-source.R
+++ b/tests/testthat/test-source.R
@@ -49,7 +49,7 @@ test_that("`options` override `toolchain` value in `rust_source`", {
   skip_on_cran()
 
   withr::local_options(rextendr.toolchain = "Non-existent-toolchain")
-  expect_rextendr_error(rust_function("fn rust_test() {}"), "Rust code could not be compiled successfully. Aborting.")
+  testthat::expect_error(rust_function("fn rust_test() {}"))
 })
 
 test_that("`options` override `patch.crates_io` value in `rust_source`", {
@@ -57,7 +57,7 @@ test_that("`options` override `patch.crates_io` value in `rust_source`", {
   skip_on_cran()
 
   withr::local_options(rextendr.patch.crates_io = list(`extendr-api` = "-1"))
-  expect_rextendr_error(rust_function("fn rust_test() {}"), "Rust code could not be compiled successfully. Aborting.")
+  testthat::expect_error(rust_function("fn rust_test() {}"))
 })
 
 
@@ -66,7 +66,7 @@ test_that("`options` override `rextendr.extendr_deps` value in `rust_source`", {
   skip_on_cran()
 
   withr::local_options(rextendr.extendr_deps = list(`extendr-api` = "-1"))
-  expect_rextendr_error(rust_function("fn rust_test() {}"), "Rust code could not be compiled successfully. Aborting.")
+  testthat::expect_error(rust_function("fn rust_test() {}"))
 })
 
 test_that("`rust_source` works even when the PATH is not set correctly, which mainly happens on macOS", {
@@ -78,7 +78,11 @@ test_that("`rust_source` works even when the PATH is not set correctly, which ma
   # Construct PATH without ~/.cargo/bin
   local_path <- Sys.getenv("PATH")
   local_path <- stringi::stri_split_fixed(local_path, ":")[[1]]
-  local_path <- stringi::stri_subset_fixed(local_path, ".cargo/bin", negate = TRUE)
+  local_path <- stringi::stri_subset_fixed(
+    local_path,
+    ".cargo/bin",
+    negate = TRUE
+  )
   local_path <- glue_collapse(local_path, sep = ":")
 
   withr::local_envvar(PATH = local_path)


### PR DESCRIPTION
The `rlang::try_fetch()` around `run_cargo()` in `rust_source()` was suppressing helpful debugging information from `cargo`. It was largely superfluous, too, since `run_cargo()` already does the necessary erorr handling and passes down the call environment, so this PR simply removes the `try_fetch()`. 

This surfaced a few issues with type checking in `rust_function()`, notably missing type checks in `check_extendr_fn_options()`. I fixed those and also took the liberty of simplifying the check logic a bit, too, since there are only four options to check. This involved handing off more type-check responsibility to the stand-alone tools. 

Finally, I updated some `testthat::expect_error()` tests `test-source.R`, which were using regex to evaluate error messages from the `try_fetch()`. Those tests now just check that errors are thrown. 

Note: this also involved removing the `rextendr_error` class, which is no longer emitted from `rust_source()` and co when cargo fails.