### PR TITLE
fix: align cargo invocations in Makevars templates so deps build once (#1087)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,13 @@
+# rextendr (development version)
+
+## Fixed
+* The `Makevars.in` / `Makevars.win.in` templates installed by `use_extendr()`
+  now pass identical `RUSTFLAGS`, `@PANIC_EXPORTS@` (Unix), and `@PROFILE@`
+  to both the `cargo build --lib` and `cargo run --bin document` invocations.
+  Previously the second invocation ran with neither, which gave it a different
+  fingerprint and caused `cargo` to rebuild every dependency from scratch on
+  package install. ([extendr/extendr#1087](https://github.com/extendr/extendr/issues/1087))
+
 # rextendr 0.5.0
 
 ## Added

--- a/inst/templates/Makevars.in
+++ b/inst/templates/Makevars.in
@@ -43,7 +43,7 @@ $(STATLIB):
 	# fresh fingerprint and rebuilds every dependency from scratch (#1087).
 	export CARGO_HOME=$(CARGOTMP) && \
 	export PATH="$(PATH):$(HOME)/.cargo/bin" && \
-	@PANIC_EXPORTS@RUSTFLAGS="$(RUSTFLAGS) --print=native-static-libs" cargo run @CRAN_FLAGS@ --bin document @PROFILE@ --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR) @TARGET@
+	@PANIC_EXPORTS@RUSTFLAGS="$(RUSTFLAGS)" cargo run @CRAN_FLAGS@ --bin document @PROFILE@ --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR) @TARGET@
 
 	# Always clean up CARGOTMP
 	rm -Rf $(CARGOTMP);

--- a/inst/templates/Makevars.in
+++ b/inst/templates/Makevars.in
@@ -38,9 +38,12 @@ $(STATLIB):
 	export PATH="$(PATH):$(HOME)/.cargo/bin" && \
 	@PANIC_EXPORTS@RUSTFLAGS="$(RUSTFLAGS) --print=native-static-libs" cargo build @CRAN_FLAGS@ --lib @PROFILE@ --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR) @TARGET@
 
+	# NOTE: env (RUSTFLAGS, @PANIC_EXPORTS@) and @PROFILE@ must match the
+	# `cargo build --lib` invocation above; otherwise cargo treats this as a
+	# fresh fingerprint and rebuilds every dependency from scratch (#1087).
 	export CARGO_HOME=$(CARGOTMP) && \
 	export PATH="$(PATH):$(HOME)/.cargo/bin" && \
-	cargo run @CRAN_FLAGS@ --bin document --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR) @TARGET@
+	@PANIC_EXPORTS@RUSTFLAGS="$(RUSTFLAGS) --print=native-static-libs" cargo run @CRAN_FLAGS@ --bin document @PROFILE@ --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR) @TARGET@
 
 	# Always clean up CARGOTMP
 	rm -Rf $(CARGOTMP);

--- a/inst/templates/Makevars.win.in
+++ b/inst/templates/Makevars.win.in
@@ -36,10 +36,13 @@ $(STATLIB):
 	export LIBRARY_PATH="$(LIBRARY_PATH);$(CURDIR)/$(TARGET_DIR)/libgcc_mock" && \
 	RUSTFLAGS="$(RUSTFLAGS) --print=native-static-libs" cargo build @CRAN_FLAGS@ --target=$(TARGET) --lib @PROFILE@ --manifest-path=rust/Cargo.toml --target-dir=$(TARGET_DIR)
 
-	# Generate wrappers
+	# Generate wrappers.
+	# NOTE: RUSTFLAGS and @PROFILE@ must match the `cargo build --lib` invocation
+	# above; otherwise cargo treats this as a fresh fingerprint and rebuilds every
+	# dependency from scratch (#1087).
 	export CARGO_HOME=$(CARGOTMP) && \
 	export PATH="$(PATH):$(HOME)/.cargo/bin" && \
-	cargo run @CRAN_FLAGS@ --bin document --target $(TARGET) --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
+	RUSTFLAGS="$(RUSTFLAGS) --print=native-static-libs" cargo run @CRAN_FLAGS@ --bin document --target $(TARGET) @PROFILE@ --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
 
 	# Always clean up CARGOTMP
 	rm -Rf $(CARGOTMP);

--- a/inst/templates/Makevars.win.in
+++ b/inst/templates/Makevars.win.in
@@ -42,7 +42,7 @@ $(STATLIB):
 	# dependency from scratch (#1087).
 	export CARGO_HOME=$(CARGOTMP) && \
 	export PATH="$(PATH):$(HOME)/.cargo/bin" && \
-	RUSTFLAGS="$(RUSTFLAGS) --print=native-static-libs" cargo run @CRAN_FLAGS@ --bin document --target $(TARGET) @PROFILE@ --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
+	RUSTFLAGS="$(RUSTFLAGS)" cargo run @CRAN_FLAGS@ --bin document --target $(TARGET) @PROFILE@ --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
 
 	# Always clean up CARGOTMP
 	rm -Rf $(CARGOTMP);

--- a/tests/testthat/_snaps/use_extendr.md
+++ b/tests/testthat/_snaps/use_extendr.md
@@ -239,7 +239,7 @@
       	# fresh fingerprint and rebuilds every dependency from scratch (#1087).
       	export CARGO_HOME=$(CARGOTMP) && \
       	export PATH="$(PATH):$(HOME)/.cargo/bin" && \
-      	@PANIC_EXPORTS@RUSTFLAGS="$(RUSTFLAGS) --print=native-static-libs" cargo run @CRAN_FLAGS@ --bin document @PROFILE@ --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR) @TARGET@
+      	@PANIC_EXPORTS@RUSTFLAGS="$(RUSTFLAGS)" cargo run @CRAN_FLAGS@ --bin document @PROFILE@ --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR) @TARGET@
       
       	# Always clean up CARGOTMP
       	rm -Rf $(CARGOTMP);
@@ -315,7 +315,7 @@
       	# dependency from scratch (#1087).
       	export CARGO_HOME=$(CARGOTMP) && \
       	export PATH="$(PATH):$(HOME)/.cargo/bin" && \
-      	RUSTFLAGS="$(RUSTFLAGS) --print=native-static-libs" cargo run @CRAN_FLAGS@ --bin document --target $(TARGET) @PROFILE@ --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
+      	RUSTFLAGS="$(RUSTFLAGS)" cargo run @CRAN_FLAGS@ --bin document --target $(TARGET) @PROFILE@ --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
       
       	# Always clean up CARGOTMP
       	rm -Rf $(CARGOTMP);
@@ -539,7 +539,7 @@
       	# fresh fingerprint and rebuilds every dependency from scratch (#1087).
       	export CARGO_HOME=$(CARGOTMP) && \
       	export PATH="$(PATH):$(HOME)/.cargo/bin" && \
-      	@PANIC_EXPORTS@RUSTFLAGS="$(RUSTFLAGS) --print=native-static-libs" cargo run @CRAN_FLAGS@ --bin document @PROFILE@ --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR) @TARGET@
+      	@PANIC_EXPORTS@RUSTFLAGS="$(RUSTFLAGS)" cargo run @CRAN_FLAGS@ --bin document @PROFILE@ --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR) @TARGET@
       
       	# Always clean up CARGOTMP
       	rm -Rf $(CARGOTMP);

--- a/tests/testthat/_snaps/use_extendr.md
+++ b/tests/testthat/_snaps/use_extendr.md
@@ -234,9 +234,12 @@
       	export PATH="$(PATH):$(HOME)/.cargo/bin" && \
       	@PANIC_EXPORTS@RUSTFLAGS="$(RUSTFLAGS) --print=native-static-libs" cargo build @CRAN_FLAGS@ --lib @PROFILE@ --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR) @TARGET@
       
+      	# NOTE: env (RUSTFLAGS, @PANIC_EXPORTS@) and @PROFILE@ must match the
+      	# `cargo build --lib` invocation above; otherwise cargo treats this as a
+      	# fresh fingerprint and rebuilds every dependency from scratch (#1087).
       	export CARGO_HOME=$(CARGOTMP) && \
       	export PATH="$(PATH):$(HOME)/.cargo/bin" && \
-      	cargo run @CRAN_FLAGS@ --bin document --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR) @TARGET@
+      	@PANIC_EXPORTS@RUSTFLAGS="$(RUSTFLAGS) --print=native-static-libs" cargo run @CRAN_FLAGS@ --bin document @PROFILE@ --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR) @TARGET@
       
       	# Always clean up CARGOTMP
       	rm -Rf $(CARGOTMP);
@@ -306,10 +309,13 @@
       	export LIBRARY_PATH="$(LIBRARY_PATH);$(CURDIR)/$(TARGET_DIR)/libgcc_mock" && \
       	RUSTFLAGS="$(RUSTFLAGS) --print=native-static-libs" cargo build @CRAN_FLAGS@ --target=$(TARGET) --lib @PROFILE@ --manifest-path=rust/Cargo.toml --target-dir=$(TARGET_DIR)
       
-      	# Generate wrappers
+      	# Generate wrappers.
+      	# NOTE: RUSTFLAGS and @PROFILE@ must match the `cargo build --lib` invocation
+      	# above; otherwise cargo treats this as a fresh fingerprint and rebuilds every
+      	# dependency from scratch (#1087).
       	export CARGO_HOME=$(CARGOTMP) && \
       	export PATH="$(PATH):$(HOME)/.cargo/bin" && \
-      	cargo run @CRAN_FLAGS@ --bin document --target $(TARGET) --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
+      	RUSTFLAGS="$(RUSTFLAGS) --print=native-static-libs" cargo run @CRAN_FLAGS@ --bin document --target $(TARGET) @PROFILE@ --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
       
       	# Always clean up CARGOTMP
       	rm -Rf $(CARGOTMP);
@@ -528,9 +534,12 @@
       	export PATH="$(PATH):$(HOME)/.cargo/bin" && \
       	@PANIC_EXPORTS@RUSTFLAGS="$(RUSTFLAGS) --print=native-static-libs" cargo build @CRAN_FLAGS@ --lib @PROFILE@ --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR) @TARGET@
       
+      	# NOTE: env (RUSTFLAGS, @PANIC_EXPORTS@) and @PROFILE@ must match the
+      	# `cargo build --lib` invocation above; otherwise cargo treats this as a
+      	# fresh fingerprint and rebuilds every dependency from scratch (#1087).
       	export CARGO_HOME=$(CARGOTMP) && \
       	export PATH="$(PATH):$(HOME)/.cargo/bin" && \
-      	cargo run @CRAN_FLAGS@ --bin document --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR) @TARGET@
+      	@PANIC_EXPORTS@RUSTFLAGS="$(RUSTFLAGS) --print=native-static-libs" cargo run @CRAN_FLAGS@ --bin document @PROFILE@ --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR) @TARGET@
       
       	# Always clean up CARGOTMP
       	rm -Rf $(CARGOTMP);


### PR DESCRIPTION
## Summary

Closes [extendr/extendr#1087](https://github.com/extendr/extendr/issues/1087).

The `Makevars.in` / `Makevars.win.in` templates installed by `use_extendr()` run
`cargo build --lib` with `RUSTFLAGS="$(RUSTFLAGS) --print=native-static-libs"`
and `@PROFILE@`, then `cargo run --bin document` with **neither**. The two
invocations therefore have different cargo fingerprints, so every dependency
is rebuilt from scratch on `R CMD INSTALL`.

This PR appends the same `RUSTFLAGS` (and `@PANIC_EXPORTS@` on Unix) and
`@PROFILE@` to the `cargo run --bin document` line, and adds an inline NOTE
documenting the invariant so the next refactor doesn't drop it again.

Diagnosis and verified fix come from `@aquasync` in the issue thread; CGMossa
endorsed it there. NEWS.md gets a `# rextendr (development version)` section.

## Out of scope

- The deeper sibling issue
  [extendr/extendr#1086](https://github.com/extendr/extendr/issues/1086)
  (library size doubled in 0.9.0) wants the `document` binary moved to an
  `examples/` target so it stops dragging the lib's optional deps into the
  `.so`. That's a structural change to the template; left for a separate PR.
- `tests/extendrtests/src/Makevars.in` in `extendr/extendr` is a *generated*
  copy of this template and still contains the old wording. Regenerating it
  there is a one-line follow-up in that repo.

## Test plan

- [ ] Smoke-run `use_extendr()` against a fresh tempdir package, install with
      `R CMD INSTALL`, confirm only one cargo compile pass.
- [ ] CI green.