### PR TITLE
chore(ci): bump GitHub Actions to current major versions

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -37,7 +37,7 @@ jobs:
       REXTENDR_SKIP_DEV_TESTS: TRUE # TODO: Remove this when extendr/libR-sys issue is resolved
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: dtolnay/rust-toolchain@master
         with:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -19,7 +19,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-r@v2
         with:

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -22,7 +22,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
@@ -43,7 +43,7 @@ jobs:
 
       - name: Deploy to GitHub pages 🚀
         if: github.event_name != 'pull_request'
-        uses: JamesIves/github-pages-deploy-action@4.1.4
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
           clean: false
           branch: gh-pages

--- a/.github/workflows/pr-commands.yaml
+++ b/.github/workflows/pr-commands.yaml
@@ -14,7 +14,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/pr-fetch@v2
         with:
@@ -52,7 +52,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/pr-fetch@v2
         with:

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -17,7 +17,7 @@ jobs:
       REXTENDR_SKIP_DEV_TESTS: TRUE # TODO: Remove this when extendr/libR-sys issue is resolved
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-r@v2
         with:
@@ -38,7 +38,7 @@ jobs:
           covr::to_cobertura(cov)
         shell: Rscript {0}
 
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v6
         with:
           # Fail if error if not on PR, or if on PR and token is given
           fail_ci_if_error: ${{ github.event_name != 'pull_request' || secrets.CODECOV_TOKEN }}
@@ -56,7 +56,7 @@ jobs:
 
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-test-failures
           path: ${{ runner.temp }}/package


### PR DESCRIPTION
The R-CMD-check runs have been emitting Node.js 20 deprecation warnings on every job — `actions/checkout@v4` is pinned to a Node 20 runtime, and GitHub is going to force Node 24 by default in June 2026 (with a hard removal of Node 20 in September). This PR bumps the still-on-old-major actions to their current floating major tag so we get the Node 24 runtimes for free and stop generating noise in the CI logs. Bumps cover `actions/checkout`, `actions/upload-artifact`, `codecov/codecov-action`, and `JamesIves/github-pages-deploy-action`.

<details>
<summary><h4>AI-written details</h4></summary>

## Summary
- `actions/checkout@v3` and `@v4` → `@v6` (5 occurrences across R-CMD-check, lint, pkgdown, test-coverage, pr-commands). Latest is `v6.0.2`.
- `actions/upload-artifact@v4` → `@v7` (1 occurrence in test-coverage). Latest is `v7.0.1`.
- `codecov/codecov-action@v4` → `@v6` (1 occurrence in test-coverage). Latest is `v6.0.0`.
- `JamesIves/github-pages-deploy-action@4.1.4` → `@v4` (1 occurrence in pkgdown). This one was pinned to an exact 4.1.4 release; moving it to the floating major tag so it tracks within v4. Latest is `v4.8.0`.

## Untouched (intentional)
- `r-lib/actions/*@v2` — v2 is still the current floating major.
- `Swatinem/rust-cache@v2` — current major.
- `baptiste0928/cargo-install@v3` — current major.
- `dtolnay/rust-toolchain@master` and `@stable` — these are branch refs, not version tags. That's the action's documented usage.

## Notes
- The actual deprecation warning the GitHub runner is currently logging on every R-CMD-check job: _"Node.js 20 actions are deprecated... actions/checkout@v4... Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026."_
- No behavior change is expected from these bumps. They are runtime / minor-feature updates within the same action contracts. If CI flags anything, it'll most likely be `codecov-action` v4→v6 — that one has had small input changes between majors. Worth eyeballing the test-coverage job log on the first run.

---
_Drafted by Claude (claude-opus-4-7). Reviewed by the author._

</details>
