### PR TITLE
update hello-world example

### DIFF
--- a/inst/templates/extendr-wrappers.R
+++ b/inst/templates/extendr-wrappers.R
@@ -6,7 +6,8 @@
 NULL
 
 #' Return string `"Hello world!"` to R.
+#' @param name A name to greet.
 #' @export
-hello_world <- function() .Call(wrap__hello_world)
+hello <- function(name) .Call(wrap__hello, name)
 
 # nolint end

--- a/inst/templates/lib.rs
+++ b/inst/templates/lib.rs
@@ -1,10 +1,11 @@
 use extendr_api::prelude::*;
 
 /// Return string `"Hello world!"` to R.
+/// @param name A name to greet.
 /// @export
 #[extendr]
-fn hello_world() -> &'static str {
-    "Hello world!"
+fn hello(name: String) -> String {
+    format!("Hello {name}!")
 }
 
 // Macro to generate exports.
@@ -12,5 +13,5 @@ fn hello_world() -> &'static str {
 // See corresponding C code in `entrypoint.c`.
 extendr_module! {
     mod {{{mod_name}}};
-    fn hello_world;
+    fn hello;
 }

--- a/tests/testthat/_snaps/document.md
+++ b/tests/testthat/_snaps/document.md
@@ -11,8 +11,9 @@
       NULL
       
       #' Return string `"Hello world!"` to R.
+      #' @param name A name to greet.
       #' @export
-      hello_world <- function() .Call(wrap__hello_world)
+      hello <- function(name) .Call(wrap__hello, name)
       
       # nolint end
 

--- a/tests/testthat/_snaps/use_extendr.md
+++ b/tests/testthat/_snaps/use_extendr.md
@@ -170,8 +170,9 @@
       NULL
       
       #' Return string `"Hello world!"` to R.
+      #' @param name A name to greet.
       #' @export
-      hello_world <- function() .Call(wrap__hello_world)
+      hello <- function(name) .Call(wrap__hello, name)
       
       # nolint end
 
@@ -369,10 +370,11 @@
       use extendr_api::prelude::*;
       
       /// Return string `"Hello world!"` to R.
+      /// @param name A name to greet.
       /// @export
       #[extendr]
-      fn hello_world() -> &'static str {
-          "Hello world!"
+      fn hello(name: String) -> String {
+          format!("Hello {name}!")
       }
       
       // Macro to generate exports.
@@ -380,7 +382,7 @@
       // See corresponding C code in `entrypoint.c`.
       extendr_module! {
           mod testpkg;
-          fn hello_world;
+          fn hello;
       }
 
 ---

--- a/tests/testthat/test-use_extendr.R
+++ b/tests/testthat/test-use_extendr.R
@@ -138,7 +138,7 @@ test_that("use_rextendr_template() can overwrite existing files", {
 
 # Check that {rextendr} works in packages containing dots in their names.
 # The check is performed by compiling the sample package and checking that
-# `hello_world()` template function is available and works.
+# `hello("world")` template function is available and works.
 test_that("use_extendr() handles R packages with dots in the name", {
   skip_if_not_installed("usethis")
   skip_if_not_installed("devtools")
@@ -150,7 +150,7 @@ test_that("use_extendr() handles R packages with dots in the name", {
   use_extendr()
   document()
   devtools::load_all()
-  expect_identical(hello_world(), "Hello world!")
+  expect_identical(hello("world"), "Hello world!")
 })
 
 # Specify crate name and library names explicitly
@@ -165,7 +165,7 @@ test_that("use_extendr() handles R package name, crate name and library name sep
   use_extendr(crate_name = "crate_name", lib_name = "lib_name")
   document()
   devtools::load_all()
-  expect_identical(hello_world(), "Hello world!")
+  expect_identical(hello("world"), "Hello world!")
 })
 
 # Pass unsupported values to `crate_name` and `lib_name` and expect errors.


### PR DESCRIPTION
This pr updates the hello-world example in the lib.rs template to show a round trip of data from R to Rust then back to R, i.e. `hello_world()` becomes `hello("world")`. This will mainly be useful for examples in the documentation.