### PR TITLE
fix: codecov v6 invalid inputs

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -42,8 +42,8 @@ jobs:
         with:
           # Fail if error if not on PR, or if on PR and token is given
           fail_ci_if_error: ${{ github.event_name != 'pull_request' || secrets.CODECOV_TOKEN }}
-          file: ./cobertura.xml
-          plugin: noop
+          files: ./cobertura.xml
+          plugins: noop
           disable_search: true
           token: ${{ secrets.CODECOV_TOKEN }}
 


### PR DESCRIPTION
We were getting this from the test-coverage action: "Warning: Unexpected input(s) 'file', 'plugin'..." And then: "Error: No coverage reports found." The solution should be to update those inputs to the plural, "files" and "plugins." Then codecov should be able to find the generated cobertura.xml report.