### PR TITLE
bug: paths with spaces fail on windows

### DIFF
--- a/inst/templates/Makevars.in
+++ b/inst/templates/Makevars.in
@@ -25,31 +25,31 @@ $(STATLIB):
 
 	if [ -d ./vendor ]; then \
 		echo "=== Using offline vendor directory ==="; \
-		mkdir -p $(CARGOTMP) && \
-		cp rust/vendor-config.toml $(CARGOTMP)/config.toml; \
+		mkdir -p "$(CARGOTMP)" && \
+		cp rust/vendor-config.toml "$(CARGOTMP)/config.toml"; \
 	elif [ -f ./rust/vendor.tar.xz ]; then \
 		echo "=== Using offline vendor tarball ==="; \
 		tar xf rust/vendor.tar.xz && \
-		mkdir -p $(CARGOTMP) && \
-		cp rust/vendor-config.toml $(CARGOTMP)/config.toml; \
+		mkdir -p "$(CARGOTMP)" && \
+		cp rust/vendor-config.toml "$(CARGOTMP)/config.toml"; \
 	fi
 
-	export CARGO_HOME=$(CARGOTMP) && \
+	export CARGO_HOME="$(CARGOTMP)" && \
 	export PATH="$(PATH):$(HOME)/.cargo/bin" && \
-	@PANIC_EXPORTS@RUSTFLAGS="$(RUSTFLAGS) --print=native-static-libs" cargo build @CRAN_FLAGS@ --lib @PROFILE@ --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR) @TARGET@
+	@PANIC_EXPORTS@RUSTFLAGS="$(RUSTFLAGS) --print=native-static-libs" cargo build @CRAN_FLAGS@ --lib @PROFILE@ --manifest-path=./rust/Cargo.toml --target-dir="$(TARGET_DIR)" @TARGET@
 
 	# NOTE: env (RUSTFLAGS, @PANIC_EXPORTS@) and @PROFILE@ must match the
 	# `cargo build --lib` invocation above; otherwise cargo treats this as a
 	# fresh fingerprint and rebuilds every dependency from scratch (#1087).
-	export CARGO_HOME=$(CARGOTMP) && \
+	export CARGO_HOME="$(CARGOTMP)" && \
 	export PATH="$(PATH):$(HOME)/.cargo/bin" && \
-	@PANIC_EXPORTS@RUSTFLAGS="$(RUSTFLAGS)" cargo run @CRAN_FLAGS@ --bin document @PROFILE@ --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR) @TARGET@
+	@PANIC_EXPORTS@RUSTFLAGS="$(RUSTFLAGS)" cargo run @CRAN_FLAGS@ --bin document @PROFILE@ --manifest-path=./rust/Cargo.toml --target-dir="$(TARGET_DIR)" @TARGET@
 
 	# Always clean up CARGOTMP
-	rm -Rf $(CARGOTMP);
+	rm -Rf "$(CARGOTMP)";
 
 rust_clean: $(SHLIB)
-	rm -Rf $(CARGOTMP) $(VENDOR_DIR) @CLEAN_TARGET@
+	rm -Rf "$(CARGOTMP)" "$(VENDOR_DIR)" @CLEAN_TARGET@
 
 clean:
-	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS) $(TARGET_DIR) $(VENDOR_DIR)
+	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS) "$(TARGET_DIR)" "$(VENDOR_DIR)"

--- a/inst/templates/Makevars.win.in
+++ b/inst/templates/Makevars.win.in
@@ -15,40 +15,40 @@ CARGOTMP = $(CURDIR)/.cargo
 VENDOR_DIR = vendor
 
 $(STATLIB):
-	mkdir -p $(TARGET_DIR)/libgcc_mock
-	touch $(TARGET_DIR)/libgcc_mock/libgcc_eh.a
+	mkdir -p "$(TARGET_DIR)/libgcc_mock"
+	touch "$(TARGET_DIR)/libgcc_mock/libgcc_eh.a"
 
   # If a vendor directory exists, it is used for offline compilation. Otherwise if
   # vendor.tar.xz exists, it is unzipped and used for offline compilation.
 	if [ -d ./vendor ]; then \
 		echo "=== Using offline vendor directory ==="; \
-		mkdir -p $(CARGOTMP) && \
-		cp rust/vendor-config.toml $(CARGOTMP)/config.toml; \
+		mkdir -p "$(CARGOTMP)" && \
+		cp rust/vendor-config.toml "$(CARGOTMP)/config.toml"; \
 	elif [ -f ./rust/vendor.tar.xz ]; then \
 		echo "=== Using offline vendor tarball ==="; \
 		tar xf rust/vendor.tar.xz && \
-		mkdir -p $(CARGOTMP) && \
-		cp rust/vendor-config.toml $(CARGOTMP)/config.toml; \
+		mkdir -p "$(CARGOTMP)" && \
+		cp rust/vendor-config.toml "$(CARGOTMP)/config.toml"; \
 	fi
 
 	# Build the project using Cargo with additional flags
-	export CARGO_HOME=$(CARGOTMP) && \
+	export CARGO_HOME="$(CARGOTMP)" && \
 	export LIBRARY_PATH="$(LIBRARY_PATH);$(CURDIR)/$(TARGET_DIR)/libgcc_mock" && \
-	RUSTFLAGS="$(RUSTFLAGS) --print=native-static-libs" cargo build @CRAN_FLAGS@ --target=$(TARGET) --lib @PROFILE@ --manifest-path=rust/Cargo.toml --target-dir=$(TARGET_DIR)
+	RUSTFLAGS="$(RUSTFLAGS) --print=native-static-libs" cargo build @CRAN_FLAGS@ --target=$(TARGET) --lib @PROFILE@ --manifest-path=rust/Cargo.toml --target-dir="$(TARGET_DIR)"
 
 	# Generate wrappers.
 	# NOTE: RUSTFLAGS and @PROFILE@ must match the `cargo build --lib` invocation
 	# above; otherwise cargo treats this as a fresh fingerprint and rebuilds every
 	# dependency from scratch (#1087).
-	export CARGO_HOME=$(CARGOTMP) && \
+	export CARGO_HOME="$(CARGOTMP)" && \
 	export PATH="$(PATH):$(HOME)/.cargo/bin" && \
-	RUSTFLAGS="$(RUSTFLAGS)" cargo run @CRAN_FLAGS@ --bin document --target $(TARGET) @PROFILE@ --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
+	RUSTFLAGS="$(RUSTFLAGS)" cargo run @CRAN_FLAGS@ --bin document --target $(TARGET) @PROFILE@ --manifest-path=./rust/Cargo.toml --target-dir "$(TARGET_DIR)"
 
 	# Always clean up CARGOTMP
-	rm -Rf $(CARGOTMP);
+	rm -Rf "$(CARGOTMP)";
 
 rust_clean: $(SHLIB)
-	rm -Rf $(CARGOTMP) $(VENDOR_DIR) @CLEAN_TARGET@
+	rm -Rf "$(CARGOTMP)" "$(VENDOR_DIR)" @CLEAN_TARGET@
 
 clean:
-	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS) $(TARGET_DIR) $(VENDOR_DIR)
+	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS) "$(TARGET_DIR)" "$(VENDOR_DIR)"

--- a/tests/testthat/_snaps/use_extendr.md
+++ b/tests/testthat/_snaps/use_extendr.md
@@ -222,34 +222,34 @@
       
       	if [ -d ./vendor ]; then \
       		echo "=== Using offline vendor directory ==="; \
-      		mkdir -p $(CARGOTMP) && \
-      		cp rust/vendor-config.toml $(CARGOTMP)/config.toml; \
+      		mkdir -p "$(CARGOTMP)" && \
+      		cp rust/vendor-config.toml "$(CARGOTMP)/config.toml"; \
       	elif [ -f ./rust/vendor.tar.xz ]; then \
       		echo "=== Using offline vendor tarball ==="; \
       		tar xf rust/vendor.tar.xz && \
-      		mkdir -p $(CARGOTMP) && \
-      		cp rust/vendor-config.toml $(CARGOTMP)/config.toml; \
+      		mkdir -p "$(CARGOTMP)" && \
+      		cp rust/vendor-config.toml "$(CARGOTMP)/config.toml"; \
       	fi
       
-      	export CARGO_HOME=$(CARGOTMP) && \
+      	export CARGO_HOME="$(CARGOTMP)" && \
       	export PATH="$(PATH):$(HOME)/.cargo/bin" && \
-      	@PANIC_EXPORTS@RUSTFLAGS="$(RUSTFLAGS) --print=native-static-libs" cargo build @CRAN_FLAGS@ --lib @PROFILE@ --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR) @TARGET@
+      	@PANIC_EXPORTS@RUSTFLAGS="$(RUSTFLAGS) --print=native-static-libs" cargo build @CRAN_FLAGS@ --lib @PROFILE@ --manifest-path=./rust/Cargo.toml --target-dir="$(TARGET_DIR)" @TARGET@
       
       	# NOTE: env (RUSTFLAGS, @PANIC_EXPORTS@) and @PROFILE@ must match the
       	# `cargo build --lib` invocation above; otherwise cargo treats this as a
       	# fresh fingerprint and rebuilds every dependency from scratch (#1087).
-      	export CARGO_HOME=$(CARGOTMP) && \
+      	export CARGO_HOME="$(CARGOTMP)" && \
       	export PATH="$(PATH):$(HOME)/.cargo/bin" && \
-      	@PANIC_EXPORTS@RUSTFLAGS="$(RUSTFLAGS)" cargo run @CRAN_FLAGS@ --bin document @PROFILE@ --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR) @TARGET@
+      	@PANIC_EXPORTS@RUSTFLAGS="$(RUSTFLAGS)" cargo run @CRAN_FLAGS@ --bin document @PROFILE@ --manifest-path=./rust/Cargo.toml --target-dir="$(TARGET_DIR)" @TARGET@
       
       	# Always clean up CARGOTMP
-      	rm -Rf $(CARGOTMP);
+      	rm -Rf "$(CARGOTMP)";
       
       rust_clean: $(SHLIB)
-      	rm -Rf $(CARGOTMP) $(VENDOR_DIR) @CLEAN_TARGET@
+      	rm -Rf "$(CARGOTMP)" "$(VENDOR_DIR)" @CLEAN_TARGET@
       
       clean:
-      	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS) $(TARGET_DIR) $(VENDOR_DIR)
+      	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS) "$(TARGET_DIR)" "$(VENDOR_DIR)"
 
 ---
 
@@ -289,43 +289,43 @@
       VENDOR_DIR = vendor
       
       $(STATLIB):
-      	mkdir -p $(TARGET_DIR)/libgcc_mock
-      	touch $(TARGET_DIR)/libgcc_mock/libgcc_eh.a
+      	mkdir -p "$(TARGET_DIR)/libgcc_mock"
+      	touch "$(TARGET_DIR)/libgcc_mock/libgcc_eh.a"
       
         # If a vendor directory exists, it is used for offline compilation. Otherwise if
         # vendor.tar.xz exists, it is unzipped and used for offline compilation.
       	if [ -d ./vendor ]; then \
       		echo "=== Using offline vendor directory ==="; \
-      		mkdir -p $(CARGOTMP) && \
-      		cp rust/vendor-config.toml $(CARGOTMP)/config.toml; \
+      		mkdir -p "$(CARGOTMP)" && \
+      		cp rust/vendor-config.toml "$(CARGOTMP)/config.toml"; \
       	elif [ -f ./rust/vendor.tar.xz ]; then \
       		echo "=== Using offline vendor tarball ==="; \
       		tar xf rust/vendor.tar.xz && \
-      		mkdir -p $(CARGOTMP) && \
-      		cp rust/vendor-config.toml $(CARGOTMP)/config.toml; \
+      		mkdir -p "$(CARGOTMP)" && \
+      		cp rust/vendor-config.toml "$(CARGOTMP)/config.toml"; \
       	fi
       
       	# Build the project using Cargo with additional flags
-      	export CARGO_HOME=$(CARGOTMP) && \
+      	export CARGO_HOME="$(CARGOTMP)" && \
       	export LIBRARY_PATH="$(LIBRARY_PATH);$(CURDIR)/$(TARGET_DIR)/libgcc_mock" && \
-      	RUSTFLAGS="$(RUSTFLAGS) --print=native-static-libs" cargo build @CRAN_FLAGS@ --target=$(TARGET) --lib @PROFILE@ --manifest-path=rust/Cargo.toml --target-dir=$(TARGET_DIR)
+      	RUSTFLAGS="$(RUSTFLAGS) --print=native-static-libs" cargo build @CRAN_FLAGS@ --target=$(TARGET) --lib @PROFILE@ --manifest-path=rust/Cargo.toml --target-dir="$(TARGET_DIR)"
       
       	# Generate wrappers.
       	# NOTE: RUSTFLAGS and @PROFILE@ must match the `cargo build --lib` invocation
       	# above; otherwise cargo treats this as a fresh fingerprint and rebuilds every
       	# dependency from scratch (#1087).
-      	export CARGO_HOME=$(CARGOTMP) && \
+      	export CARGO_HOME="$(CARGOTMP)" && \
       	export PATH="$(PATH):$(HOME)/.cargo/bin" && \
-      	RUSTFLAGS="$(RUSTFLAGS)" cargo run @CRAN_FLAGS@ --bin document --target $(TARGET) @PROFILE@ --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
+      	RUSTFLAGS="$(RUSTFLAGS)" cargo run @CRAN_FLAGS@ --bin document --target $(TARGET) @PROFILE@ --manifest-path=./rust/Cargo.toml --target-dir "$(TARGET_DIR)"
       
       	# Always clean up CARGOTMP
-      	rm -Rf $(CARGOTMP);
+      	rm -Rf "$(CARGOTMP)";
       
       rust_clean: $(SHLIB)
-      	rm -Rf $(CARGOTMP) $(VENDOR_DIR) @CLEAN_TARGET@
+      	rm -Rf "$(CARGOTMP)" "$(VENDOR_DIR)" @CLEAN_TARGET@
       
       clean:
-      	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS) $(TARGET_DIR) $(VENDOR_DIR)
+      	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS) "$(TARGET_DIR)" "$(VENDOR_DIR)"
 
 ---
 
@@ -523,32 +523,32 @@
       
       	if [ -d ./vendor ]; then \
       		echo "=== Using offline vendor directory ==="; \
-      		mkdir -p $(CARGOTMP) && \
-      		cp rust/vendor-config.toml $(CARGOTMP)/config.toml; \
+      		mkdir -p "$(CARGOTMP)" && \
+      		cp rust/vendor-config.toml "$(CARGOTMP)/config.toml"; \
       	elif [ -f ./rust/vendor.tar.xz ]; then \
       		echo "=== Using offline vendor tarball ==="; \
       		tar xf rust/vendor.tar.xz && \
-      		mkdir -p $(CARGOTMP) && \
-      		cp rust/vendor-config.toml $(CARGOTMP)/config.toml; \
+      		mkdir -p "$(CARGOTMP)" && \
+      		cp rust/vendor-config.toml "$(CARGOTMP)/config.toml"; \
       	fi
       
-      	export CARGO_HOME=$(CARGOTMP) && \
+      	export CARGO_HOME="$(CARGOTMP)" && \
       	export PATH="$(PATH):$(HOME)/.cargo/bin" && \
-      	@PANIC_EXPORTS@RUSTFLAGS="$(RUSTFLAGS) --print=native-static-libs" cargo build @CRAN_FLAGS@ --lib @PROFILE@ --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR) @TARGET@
+      	@PANIC_EXPORTS@RUSTFLAGS="$(RUSTFLAGS) --print=native-static-libs" cargo build @CRAN_FLAGS@ --lib @PROFILE@ --manifest-path=./rust/Cargo.toml --target-dir="$(TARGET_DIR)" @TARGET@
       
       	# NOTE: env (RUSTFLAGS, @PANIC_EXPORTS@) and @PROFILE@ must match the
       	# `cargo build --lib` invocation above; otherwise cargo treats this as a
       	# fresh fingerprint and rebuilds every dependency from scratch (#1087).
-      	export CARGO_HOME=$(CARGOTMP) && \
+      	export CARGO_HOME="$(CARGOTMP)" && \
       	export PATH="$(PATH):$(HOME)/.cargo/bin" && \
-      	@PANIC_EXPORTS@RUSTFLAGS="$(RUSTFLAGS)" cargo run @CRAN_FLAGS@ --bin document @PROFILE@ --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR) @TARGET@
+      	@PANIC_EXPORTS@RUSTFLAGS="$(RUSTFLAGS)" cargo run @CRAN_FLAGS@ --bin document @PROFILE@ --manifest-path=./rust/Cargo.toml --target-dir="$(TARGET_DIR)" @TARGET@
       
       	# Always clean up CARGOTMP
-      	rm -Rf $(CARGOTMP);
+      	rm -Rf "$(CARGOTMP)";
       
       rust_clean: $(SHLIB)
-      	rm -Rf $(CARGOTMP) $(VENDOR_DIR) @CLEAN_TARGET@
+      	rm -Rf "$(CARGOTMP)" "$(VENDOR_DIR)" @CLEAN_TARGET@
       
       clean:
-      	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS) $(TARGET_DIR) $(VENDOR_DIR)
+      	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS) "$(TARGET_DIR)" "$(VENDOR_DIR)"
 

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -16,14 +16,21 @@ expect_rextendr_error <- function(...) {
 #' `withr::defer()`. This clean-up happens at the end of the local scope,
 #' usually the end of a `test_that()` call.
 #'
-#' @param nm The name of the temporary package
+#' @param path The path to the temporary package, with `dirname(path)` being the
+#'   parent directory and `basename(path)` being the name of the package to
+#'   create.
 #' @param envir An environment where `withr::defer()`'s exit handler is
 #'   attached, usually the `parent.frame()` to exist locally
 #'
 #' @return A path to the root package directory
-local_package <- function(nm, envir = parent.frame()) {
-  local_temp_dir(envir = envir)
-  dir <- usethis::create_package(nm)
+local_package <- function(path, envir = parent.frame()) {
+  parent <- dirname(path)
+  if (parent == ".") {
+    local_temp_dir(envir = envir)
+  } else {
+    local_temp_dir(parent, envir = envir)
+  }
+  dir <- usethis::create_package(basename(path))
   setwd(dir)
   local_proj_set(envir = envir)
 
@@ -89,7 +96,11 @@ skip_if_cargo_unavailable <- function(args = "--help") {
       processx::run("cargo", args, error_on_status = TRUE)
     },
     error = function(e) {
-      message <- paste0("`cargo ", paste0(args, collapse = " "), "` is not available.")
+      message <- paste0(
+        "`cargo ",
+        paste0(args, collapse = " "),
+        "` is not available."
+      )
       testthat::skip(message)
     }
   )

--- a/tests/testthat/test-document.R
+++ b/tests/testthat/test-document.R
@@ -123,3 +123,22 @@ test_that("devtools::document() generates wrappers", {
   devtools::document()
   expect_snapshot(cat_file("R/extendr-wrappers.R"))
 })
+
+test_that("devtools::document() works for paths with spaces", {
+  skip_if_not_installed("usethis")
+  skip_if_not_installed("devtools")
+  skip_on_cran()
+  skip_if_cargo_unavailable()
+
+  path <- local_package("with spaces/testPackage")
+  use_extendr()
+  devtools::document()
+
+  lib_file <- file.path(
+    path,
+    "src",
+    paste0("testPackage", .Platform$dynlib.ext)
+  )
+
+  expect_true(file.exists(lib_file))
+})


### PR DESCRIPTION
Paths with spaces are failing on windows. This is owing to unquoted paths in makevars, specifically Makevars.win.in, but I went ahead and quoted paths in the unix version, too. I also introduced a new test to look for this problem, which required a small update to the test helper `local_package()`. And snapshots for makevars had to be updated.

Note: quoting happens where the full paths are constructed and not where the root variables are defined. 

Closes https://github.com/extendr/rextendr/issues/503.